### PR TITLE
Make CONJUR_VERSION an alias for CONJUR_MAJOR_VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.3.1
+
+* Make `CONJUR_VERSION` an alias for `CONJUR_MAJOR_VERSION` to match other client libraries.
+
 # v0.3.0
 
 * Adds new API methods `RotateAPIKey` and `CheckPermission`.

--- a/_setup.sh
+++ b/_setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -ex
 
 # Build test container & start the cluster
-docker-compose pull postgres conjur cuke-master
-docker-compose build --pull
+docker-compose pull conjur cuke-master
+docker-compose build
 docker-compose up -d
 docker-compose exec -T test ./wait_for_server.sh
 

--- a/conjurapi/config.go
+++ b/conjurapi/config.go
@@ -2,10 +2,11 @@ package conjurapi
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v1"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"gopkg.in/yaml.v1"
 )
 
 type Config struct {
@@ -91,13 +92,15 @@ func (c *Config) mergeYAML(filename string) {
 }
 
 func (c *Config) mergeEnv() {
+	majorVersion4 := os.Getenv("CONJUR_MAJOR_VERSION") == "4" || os.Getenv("CONJUR_VERSION") == "4"
+
 	env := Config{
 		ApplianceURL: os.Getenv("CONJUR_APPLIANCE_URL"),
 		SSLCert:      os.Getenv("CONJUR_SSL_CERTIFICATE"),
 		SSLCertPath:  os.Getenv("CONJUR_CERT_FILE"),
 		Account:      os.Getenv("CONJUR_ACCOUNT"),
 		NetRCPath:    os.Getenv("CONJUR_NETRC_PATH"),
-		V4:           os.Getenv("CONJUR_MAJOR_VERSION") == "4",
+		V4:           majorVersion4,
 	}
 
 	c.merge(&env)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
 
   conjur:
     container_name: api-go-conjur
-    image: cyberark/conjur:0.2.0-stable
+    image: cyberark/conjur
     command: server -a cucumber
     environment:
       DATABASE_URL: postgres://postgres@postgres/postgres


### PR DESCRIPTION
To match other client libraries

Happy CI job here - https://jenkins.conjur.net/job/cyberark--conjur-api-go/job/fix%252Fversion-alias/

To test this, export `CONJUR_VERSION=4` and you'll get v4 behavior.