### PR TITLE
support for `version` conjurrc attribute 

### DIFF
--- a/conjurapi/config.go
+++ b/conjurapi/config.go
@@ -88,7 +88,7 @@ func (c *Config) mergeYAML(filename string) {
 	}
 	aux.Config.V4 = aux.ConjurVersion == "4"
 
-	c.merge((*Config)(&aux.Config))
+	c.merge(&aux.Config)
 }
 
 func (c *Config) mergeEnv() {

--- a/conjurapi/config.go
+++ b/conjurapi/config.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
-
 	"gopkg.in/yaml.v1"
 )
 
@@ -74,21 +73,22 @@ func (c *Config) merge(o *Config) {
 }
 
 func (c *Config) mergeYAML(filename string) {
-	var tmp Config
-
 	buf, err := ioutil.ReadFile(filename)
 
 	if err != nil {
 		return
 	}
 
-	err = yaml.Unmarshal(buf, &tmp)
-
-	if err != nil {
+	aux := struct {
+		ConjurVersion string `yaml:"version"`
+		Config `yaml:",inline"`
+	}{}
+	if err := yaml.Unmarshal(buf, &aux); err != nil {
 		return
 	}
+	aux.Config.V4 = aux.ConjurVersion == "4"
 
-	c.merge(&tmp)
+	c.merge((*Config)(&aux.Config))
 }
 
 func (c *Config) mergeEnv() {


### PR DESCRIPTION
+ support for `version` conjurrc attribute. addresses https://github.com/cyberark/conjur-api-go/issues/18
+ added test for `TestConfig_mergeYAML`
+ see `conjurapi/config.go` and `conjurapi/config_test.go`

https://jenkins.conjur.net/job/cyberark--conjur-api-go/job/version-conjurrc