### PR TITLE
support token refreshing for APIKeyAuthenticator

### DIFF
--- a/conjurapi/authn/api_key_authenticator.go
+++ b/conjurapi/authn/api_key_authenticator.go
@@ -2,6 +2,8 @@ package authn
 
 import "time"
 
+// The four minutes is to work around a bug in Conjur < 4.7 causing a 404 on
+// long-running operations (when the token is used right around the 5 minute mark).
 var TOKEN_STALE = 4 * time.Minute
 
 type APIKeyAuthenticator struct {
@@ -24,5 +26,5 @@ func (a *APIKeyAuthenticator) RefreshToken() ([]byte, error) {
 }
 
 func (a *APIKeyAuthenticator) NeedsTokenRefresh() bool {
-	return time.Now().Sub(a.tokenBorn) > TOKEN_STALE
+	return time.Now().Sub(a.tokenBorn) >= TOKEN_STALE
 }

--- a/conjurapi/authn/api_key_authenticator_test.go
+++ b/conjurapi/authn/api_key_authenticator_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+	"time"
 )
 
 func TestAPIKeyAuthenticator_RefreshToken(t *testing.T) {
@@ -56,9 +57,15 @@ func TestAPIKeyAuthenticator_RefreshToken(t *testing.T) {
 }
 
 func TestAPIKeyAuthenticator_NeedsTokenRefresh(t *testing.T) {
-	Convey("Returns false", t, func() {
-		authenticator := APIKeyAuthenticator{}
+	Convey("Returns false when tokenBorn is not stale", t, func() {
+		authenticator := APIKeyAuthenticator{tokenBorn: time.Now()}
 
 		So(authenticator.NeedsTokenRefresh(), ShouldBeFalse)
+	})
+
+	Convey("Returns true when tokenBorn is stale", t, func() {
+		authenticator := APIKeyAuthenticator{tokenBorn: time.Now().Truncate(TOKEN_STALE)}
+
+		So(authenticator.NeedsTokenRefresh(), ShouldBeTrue)
 	})
 }

--- a/conjurapi/authn/api_key_authenticator_test.go
+++ b/conjurapi/authn/api_key_authenticator_test.go
@@ -64,7 +64,7 @@ func TestAPIKeyAuthenticator_NeedsTokenRefresh(t *testing.T) {
 	})
 
 	Convey("Returns true when tokenBorn is stale", t, func() {
-		authenticator := APIKeyAuthenticator{tokenBorn: time.Now().Truncate(TOKEN_STALE)}
+		authenticator := APIKeyAuthenticator{tokenBorn: time.Now().Add(-TOKEN_STALE)}
 
 		So(authenticator.NeedsTokenRefresh(), ShouldBeTrue)
 	})


### PR DESCRIPTION
Functionality: 4 minutes after a token is refreshed it becomes stale and needs to be refreshed again.