### PR TITLE
Fix AuthToken4 Refresh

### DIFF
--- a/conjurapi/authn/auth_token.go
+++ b/conjurapi/authn/auth_token.go
@@ -62,6 +62,9 @@ func NewToken(data []byte) (token AuthnToken, err error) {
 		err = fmt.Errorf("Unrecognized token format")
 		return
 	}
+
+	err = token.FromJSON(data)
+
 	return
 }
 

--- a/conjurapi/authn/auth_token.go
+++ b/conjurapi/authn/auth_token.go
@@ -123,7 +123,6 @@ func (t *AuthnToken4) FromJSON(data []byte) (err error) {
 func (t *AuthnToken4) UnmarshalJSON(data []byte) (err error) {
 	type Alias AuthnToken4
 	x := &struct {
-		bytes     []byte
 		Data      string `json:"data"`
 		Timestamp string `json:"timestamp"`
 		Signature string `json:"signature"`

--- a/conjurapi/authn/auth_token_test.go
+++ b/conjurapi/authn/auth_token_test.go
@@ -28,13 +28,11 @@ func TestTokenV5_Parse(t *testing.T) {
 
 		So(err, ShouldBeNil)
 		So(reflect.TypeOf(token).String(), ShouldEqual, "*authn.AuthnToken5")
-		So(token.Raw(), ShouldBeNil)
+		So(token.Raw(), ShouldNotBeNil)
 	})
 
 	Convey("Token fields are parsed as expected", t, func() {
 		token, err := NewToken([]byte(token_s))
-
-		err = token.FromJSON([]byte(token_s))
 		So(err, ShouldBeNil)
 
 		So(string(token.Raw()), ShouldEqual, token_s)
@@ -48,8 +46,6 @@ func TestTokenV5_Parse(t *testing.T) {
 
 	Convey("Token exp is supported", t, func() {
 		token, err := NewToken([]byte(token_with_exp_s))
-
-		err = token.FromJSON([]byte(token_with_exp_s))
 		So(err, ShouldBeNil)
 
 		token_v5 := token.(*AuthnToken5)
@@ -60,16 +56,12 @@ func TestTokenV5_Parse(t *testing.T) {
 	})
 
 	Convey("Malformed base64 in token is reported", t, func() {
-		token, err := NewToken([]byte(token_mangled_s))
-
-		err = token.FromJSON([]byte(token_mangled_s))
+		_, err := NewToken([]byte(token_mangled_s))
 		So(err.Error(), ShouldEqual, "v5 access token field 'payload' is not valid base64")
 	})
 
 	Convey("Malformed JSON in token is reported", t, func() {
-		token, err := NewToken([]byte(token_mangled_2_s))
-
-		err = token.FromJSON([]byte(token_mangled_2_s))
+		_, err := NewToken([]byte(token_mangled_2_s))
 		So(err.Error(), ShouldEqual, "Unable to unmarshal v5 access token field 'payload' : invalid character 'o' in literal false (expecting 'a')")
 	})
 }
@@ -80,7 +72,6 @@ func TestTokenV4_Parse(t *testing.T) {
 
 	Convey("Token type V4 is detected", t, func() {
 		token, err := NewToken(expired_token_bytes)
-		err = token.FromJSON(expired_token_bytes)
 
 		So(err, ShouldBeNil)
 		So(reflect.TypeOf(token).String(), ShouldEqual, "*authn.AuthnToken4")
@@ -134,7 +125,6 @@ func TestTokenV4_Parse(t *testing.T) {
 
 	Convey("New token can be parsed and fields are valid", t, func() {
 		token, err := NewToken([]byte(new_token_bytes))
-		err = token.FromJSON(new_token_bytes)
 		token4, _ := token.(*AuthnToken4)
 
 		So(err, ShouldBeNil)

--- a/conjurapi/authn/auth_token_test.go
+++ b/conjurapi/authn/auth_token_test.go
@@ -1,10 +1,19 @@
 package authn
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
 	"reflect"
 	"testing"
 	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestTokenV5_Parse(t *testing.T) {
@@ -62,5 +71,76 @@ func TestTokenV5_Parse(t *testing.T) {
 
 		err = token.FromJSON([]byte(token_mangled_2_s))
 		So(err.Error(), ShouldEqual, "Unable to unmarshal v5 access token field 'payload' : invalid character 'o' in literal false (expecting 'a')")
+	})
+}
+
+func TestTokenV4_Parse(t *testing.T) {
+	expired_token_bytes := []byte(`{"data":"admin","timestamp":"2018-04-06 03:10:08 UTC","signature":"QxTMoWWYXbgMo_JuX4KHQuiPwPRe8fpIlnZMhlvHalyhJHK0RbkqOyw28ImLwClBaTPjx6KU7KmqYLi9pMszHQZhQ7A2fLm1v-x0XzZGrDOt6gd0fTEZ0CJl7VVxVBZWLrJ83r8tY-sdjKysrE1fyDXyMU_vDtgJVi9y72qddkH-Pl16Pd4PJceEEybfWylIs1Z5V5qn-ocWX18D-i9pB67Usz3m-wKa43TptiDYLGU1-Y_EXyilv_uNGouqwYa0IueK5yJxO1Rcyb2aCBG0i-0Vl7qYrT0zIwDqmxLAwbqOtrtfHngFOCqsW04jJLPOruR5FwMlGw90GT1lZH_3GCm6QK8p15IWfVS9UOky8Y4l-1vfh-d15BZPGemUbu0j","key":"86ffd9d612ad06fe978b559fbeba4ca2"}`)
+	var expired_token *AuthnToken4
+
+	Convey("Token type V4 is detected", t, func() {
+		token, err := NewToken(expired_token_bytes)
+		err = token.FromJSON(expired_token_bytes)
+
+		So(err, ShouldBeNil)
+		So(reflect.TypeOf(token).String(), ShouldEqual, "*authn.AuthnToken4")
+		So(token.Raw(), ShouldNotBeNil)
+
+		expired_token, _ = token.(*AuthnToken4)
+	})
+
+	Convey("Token timestamp is non-zero", t, func() {
+		So(expired_token.Timestamp.IsZero(), ShouldEqual, false)
+	})
+
+	Convey("Expired token should be refreshed", t, func() {
+		So(expired_token.ShouldRefresh(), ShouldEqual, true)
+	})
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	httpClient := http.Client{Transport: tr}
+
+	authUrl := fmt.Sprintf("%s/authn/users/%s/authenticate",
+		os.Getenv("CONJUR_V4_APPLIANCE_URL"),
+		url.PathEscape(os.Getenv("CONJUR_V4_AUTHN_LOGIN")))
+
+	req, err := http.NewRequest("POST",
+		authUrl,
+		bytes.NewBuffer([]byte(os.Getenv("CONJUR_V4_AUTHN_API_KEY"))))
+
+	if err != nil {
+		log.Printf("Failed creating request to authenticate: %s\n", err)
+		log.Println("Cannot continue.")
+		return
+	}
+
+	req.Header.Set("Accept", "*/*")
+	res, err := httpClient.Do(req)
+	if err != nil {
+		log.Printf("Failed creating request to authenticate: %s\n", err)
+		log.Println("Cannot continue.")
+		return
+	}
+
+	if res.StatusCode != http.StatusOK {
+		log.Printf("Received %d response when authenticating.\n", res.StatusCode)
+		log.Println("Cannot continue.")
+	}
+
+	new_token_bytes, _ := ioutil.ReadAll(res.Body)
+
+	Convey("New token can be parsed and fields are valid", t, func() {
+		token, err := NewToken([]byte(new_token_bytes))
+		err = token.FromJSON(new_token_bytes)
+		token4, _ := token.(*AuthnToken4)
+
+		So(err, ShouldBeNil)
+		So(reflect.TypeOf(token).String(), ShouldEqual, "*authn.AuthnToken4")
+		So(token4.Timestamp.IsZero(), ShouldEqual, false)
+		So(token.ShouldRefresh(), ShouldEqual, false)
+		So(token.Raw(), ShouldNotBeNil)
 	})
 }


### PR DESCRIPTION
I came across some issues that caused the AuthToken4 not to be refreshed after the initial token expired.

Firstly, unmarshalling the JSON token was failing on the `timestamp` field. I removed the duplicate string field and implemented the [`Unmarshaler`](https://golang.org/pkg/encoding/json/#Unmarshaler) interface to clean things up.

Second, `FromJSON` is now called from `NewToken` since JSON was being passed in anyway.

Then lastly the `RefreshToken` function was just backwards. I fixed it.