### PR TITLE
Add ability to retrieve batch secrets

### DIFF
--- a/_setup.sh
+++ b/_setup.sh
@@ -27,8 +27,34 @@ api_key=$(exec_on conjur conjurctl role retrieve-key cucumber:user:admin | tr -d
 exec_on cuke-master bash -c 'conjur authn login -u admin -p secret'
 exec_on cuke-master conjur user create --as-group security_admin alice
 exec_on cuke-master conjur variable create existent-variable-with-undefined-value
-exec_on cuke-master conjur variable create existent-variable-with-defined-value
-exec_on cuke-master conjur variable values add existent-variable-with-defined-value existent-variable-defined-value
+
+vars=(
+  'existent-variable-with-defined-value'
+  'myapp-01'
+  'alice@devops'
+  'prod/aws/db-password'
+  'research+development'
+  'sales&marketing'
+  'onemore'
+)
+
+secrets=(
+  'existent-variable-defined-value'
+  'these'
+  'are'
+  'all'
+  'secret'
+  'strings'
+  '{"json": "object"}'
+)
+
+count=${#vars[@]}
+for ((i=0; i<$count; i++)); do
+  id="${vars[$i]}"
+  val="${secrets[$i]}"
+  exec_on cuke-master conjur variable create "$id"
+  exec_on cuke-master conjur variable values add "$id" "$val"
+done
 
 api_key_v4=$(exec_on cuke-master conjur user rotate_api_key)
 ssl_cert_v4=$(exec_on cuke-master cat /opt/conjur/etc/ssl/ca.pem)

--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -40,6 +40,8 @@ type Router interface {
 
 	RetrieveSecretRequest(variableID string) (*http.Request, error)
 
+	RetrieveBatchSecretsRequest(variableIDs []string) (*http.Request, error)
+
 	LoadPolicyRequest(mode PolicyMode, policyID string, policy io.Reader) (*http.Request, error)
 }
 

--- a/conjurapi/router_v4.go
+++ b/conjurapi/router_v4.go
@@ -74,6 +74,14 @@ func (r RouterV4) AddSecretRequest(variableIDentifier, secretValue string) (*htt
 	return nil, fmt.Errorf("AddSecret is not supported for Conjur V4")
 }
 
+func (r RouterV4) RetrieveBatchSecretsRequest(variableIDs []string) (*http.Request, error) {
+	return http.NewRequest(
+		"GET",
+		r.batchVariableURL(variableIDs),
+		nil,
+	)
+}
+
 func (r RouterV4) RetrieveSecretRequest(variableIDentifier string) (*http.Request, error) {
 	return http.NewRequest(
 		"GET",
@@ -84,4 +92,9 @@ func (r RouterV4) RetrieveSecretRequest(variableIDentifier string) (*http.Reques
 
 func (r RouterV4) variableURL(variableIDentifier string) string {
 	return fmt.Sprintf("%s/variables/%s/value", r.Config.ApplianceURL, url.QueryEscape(variableIDentifier))
+}
+
+func (r RouterV4) batchVariableURL(variableIDs []string) string {
+	queryString := url.QueryEscape(strings.Join(variableIDs, ","))
+	return fmt.Sprintf("%s/variables/values?vars=%s", r.Config.ApplianceURL, queryString)
 }

--- a/conjurapi/router_v5.go
+++ b/conjurapi/router_v5.go
@@ -75,6 +75,20 @@ func (r RouterV5) LoadPolicyRequest(mode PolicyMode, policyID string, policy io.
 	)
 }
 
+func (r RouterV5) RetrieveBatchSecretsRequest(variableIDs []string) (*http.Request, error) {
+	fullVariableIDs := []string{}
+	for _, variable := range variableIDs {
+		variableID := makeFullId(r.Config.Account, "variable", variable)
+		fullVariableIDs = append(fullVariableIDs, variableID)
+	}
+
+	return http.NewRequest(
+		"GET",
+		r.batchVariableURL(fullVariableIDs),
+		nil,
+	)
+}
+
 func (r RouterV5) RetrieveSecretRequest(variableID string) (*http.Request, error) {
 	variableID = makeFullId(r.Config.Account, "variable", variableID)
 
@@ -98,4 +112,9 @@ func (r RouterV5) AddSecretRequest(variableID, secretValue string) (*http.Reques
 func (r RouterV5) variableURL(variableID string) string {
 	tokens := strings.SplitN(variableID, ":", 3)
 	return fmt.Sprintf("%s/secrets/%s/%s/%s", r.Config.ApplianceURL, tokens[0], tokens[1], url.QueryEscape(tokens[2]))
+}
+
+func (r RouterV5) batchVariableURL(variableIDs []string) string {
+	queryString := url.QueryEscape(strings.Join(variableIDs, ","))
+	return fmt.Sprintf("%s/secrets?variable_ids=%s", r.Config.ApplianceURL, queryString)
 }

--- a/conjurapi/variable.go
+++ b/conjurapi/variable.go
@@ -4,8 +4,39 @@ import (
 	"io"
 	"net/http"
 
+	"encoding/json"
+
 	"github.com/cyberark/conjur-api-go/conjurapi/response"
 )
+
+// RetrieveBatchSecrets fetches values for all variables in a slice using a
+// single API call
+//
+// The authenticated user must have execute privilege on all variables.
+func (c *Client) RetrieveBatchSecrets(variableIDs []string) (map[string][]byte, error) {
+	resp, err := c.retrieveBatchSecrets(variableIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := response.DataResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonResponse := map[string]string{}
+	err = json.Unmarshal(data, &jsonResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedVariables := map[string][]byte{}
+	for id, value := range jsonResponse {
+		resolvedVariables[id] = []byte(value)
+	}
+
+	return resolvedVariables, nil
+}
 
 // RetrieveSecret fetches a secret from a variable.
 //
@@ -31,6 +62,16 @@ func (c *Client) RetrieveSecretReader(variableID string) (io.ReadCloser, error) 
 
 	return response.SecretDataResponse(resp)
 }
+
+func (c *Client) retrieveBatchSecrets(variableIDs []string) (*http.Response, error) {
+	req, err := c.router.RetrieveBatchSecretsRequest(variableIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.SubmitRequest(req)
+}
+
 func (c *Client) retrieveSecret(variableID string) (*http.Response, error) {
 	req, err := c.router.RetrieveSecretRequest(variableID)
 	if err != nil {


### PR DESCRIPTION
This change exposes the batch secret retrieval endpoint for both V4 and V5. You can access it via the `RetrieveBatchSecrets` method on the `Client` struct.

Tests are included. Run `./test.sh`.