### PR TITLE
add support for fetching resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
-# v0.3.3
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+* Add `Resource`, to fetch a resource by id.
+* Add `Resources`, to show all resources, optionally filtered by a `ResourceFilter`.
+* Use a separate logrus logger for the API. Control the destination for messages with the
+  environment variable `CONJURAPI_LOG`.
+
+# [0.3.3]
 
 * Update the tags on `PolicyResponse` so they match the JSON returned by the server.
 
-# v0.3.2
+# 0.3.2
 
 * Use github.com/sirupsen/logrus for logging.
 * When the log level for logrus is set to DebugLevel, show debug information, including:
@@ -14,23 +27,29 @@
   * the HTTP request sent to, and the responses received from, the Conjur server
   
 
-# v0.3.1
+# 0.3.1
 
 * Make `CONJUR_VERSION` an alias for `CONJUR_MAJOR_VERSION` to match other client libraries.
 
-# v0.3.0
+# [0.3.0]
 
 * Adds new API methods `RotateAPIKey` and `CheckPermission`.
 * Provides API methods that return secret data as an `io.ReadCloser` rather than of `[]byte`. This way, the API client gets the only copy of the secret data and can handle it however she sees fit.
 * Loading a policy requires `PolicyMode` argument.
 * Loading a policy returns `PolicyResponse`. 
 
-# v0.2.0
+# [0.2.0]
 
 * Adds support for structured error responses from the Conjur v5 server, using the struct `conjurapi.ConjurError`. This is a backwards incompatible change.
 * All API methods accept fully qualified object ids in v5 mode. This is a backwards compatible bug fix.
 * API methods which do not work in v4 mode return an appropriate error message. This is a backwards compatible bug fix.
 
-# v0.1.0
+# 0.1.0
 
 * Initial version
+
+[Unreleased]: https://github.com/cyberark/conjur-api-go/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/cyberark/conjur-api-go/compare/v0.3.0...v0.3.3
+[0.3.0]: https://github.com/cyberark/conjur-api-go/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/cyberark/conjur-api-go/compare/v0.1.0...v0.2.0
+

--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -157,6 +157,15 @@ func makeFullId(account, kind, id string) string {
 	return strings.Join(tokens, ":")
 }
 
+func parseID(fullID string) (account, kind, id string, err error) {
+	tokens := strings.SplitN(fullID, ":", 3)
+	if len(tokens) != 3 {
+		err = fmt.Errorf("Id '%s' must be fully qualified", fullID)
+		return
+	}
+	return tokens[0], tokens[1], tokens[2], nil
+}
+
 func newClientWithAuthenticator(config Config, authenticator Authenticator) (*Client, error) {
 	var (
 		err error

--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/bgentry/go-netrc/netrc"
 	"github.com/cyberark/conjur-api-go/conjurapi/authn"
-	log "github.com/sirupsen/logrus"
+	"github.com/cyberark/conjur-api-go/conjurapi/logging"
 )
 
 type Authenticator interface {
@@ -137,7 +137,7 @@ func (c *Client) SubmitRequest(req *http.Request) (resp *http.Response, err erro
 		return
 	}
 
-	log.Debugf("req: %+v\n", req)
+	logging.ApiLog.Debugf("req: %+v\n", req)
 	resp, err = c.httpClient.Do(req)
 	if err != nil {
 		return

--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -30,19 +30,15 @@ type Client struct {
 }
 
 type Router interface {
-	AuthenticateRequest(loginPair authn.LoginPair) (*http.Request, error)
-
-	RotateAPIKeyRequest(roleID string) (*http.Request, error)
-
-	CheckPermissionRequest(resourceID, privilege string) (*http.Request, error)
-
 	AddSecretRequest(variableID, secretValue string) (*http.Request, error)
-
-	RetrieveSecretRequest(variableID string) (*http.Request, error)
-
-	RetrieveBatchSecretsRequest(variableIDs []string) (*http.Request, error)
-
+	AuthenticateRequest(loginPair authn.LoginPair) (*http.Request, error)
+	CheckPermissionRequest(resourceID, privilege string) (*http.Request, error)
 	LoadPolicyRequest(mode PolicyMode, policyID string, policy io.Reader) (*http.Request, error)
+	ResourceRequest(resourceID string) (*http.Request, error)
+	ResourcesRequest(filter *ResourceFilter) (*http.Request, error)
+	RetrieveBatchSecretsRequest(variableIDs []string) (*http.Request, error)
+	RetrieveSecretRequest(variableID string) (*http.Request, error)
+	RotateAPIKeyRequest(roleID string) (*http.Request, error)
 }
 
 func NewClientFromKey(config Config, loginPair authn.LoginPair) (*Client, error) {

--- a/conjurapi/config.go
+++ b/conjurapi/config.go
@@ -6,7 +6,8 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/cyberark/conjur-api-go/conjurapi/logging"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v1"
 )
 
@@ -35,7 +36,7 @@ func (c *Config) validate() error {
 
 	if len(errors) == 0 {
 		return nil
-	} else if log.GetLevel() == log.DebugLevel {
+	} else if logging.ApiLog.Level == logrus.DebugLevel {
 		errors = append(errors, fmt.Sprintf("config: %+v", c))
 	}
 	return fmt.Errorf("%s", strings.Join(errors, " -- "))
@@ -80,7 +81,7 @@ func (c *Config) mergeYAML(filename string) {
 	buf, err := ioutil.ReadFile(filename)
 
 	if err != nil {
-		log.Debugf("Failed reading %s, %v\n", filename, err)
+		logging.ApiLog.Debugf("Failed reading %s, %v\n", filename, err)
 		return
 	}
 
@@ -93,7 +94,7 @@ func (c *Config) mergeYAML(filename string) {
 	}
 	aux.Config.V4 = aux.ConjurVersion == "4"
 
-	log.Debugf("Config from %s: %+v\n", filename, aux.Config)
+	logging.ApiLog.Debugf("Config from %s: %+v\n", filename, aux.Config)
 	c.merge(&aux.Config)
 }
 
@@ -109,7 +110,7 @@ func (c *Config) mergeEnv() {
 		V4:           majorVersion4,
 	}
 
-	log.Debugf("Config from environment: %+v\n", env)
+	logging.ApiLog.Debugf("Config from environment: %+v\n", env)
 	c.merge(&env)
 }
 
@@ -128,6 +129,6 @@ func LoadConfig() Config {
 
 	config.mergeEnv()
 
-	log.Debugf("Final config: %+v\n", config)
+	logging.ApiLog.Debugf("Final config: %+v\n", config)
 	return config
 }

--- a/conjurapi/logging/logging.go
+++ b/conjurapi/logging/logging.go
@@ -1,0 +1,42 @@
+package logging
+
+import (
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ApiLog is a separate logrus logger for the API. The destination for
+// its messages is controlled by the environment variable
+// CONJURAPI_LOG. CONJRAPI_LOG can be "stdout", "stderr", or the path
+// to a file. If it's a path, the file's contents will be overwritten
+// with new messages.
+var ApiLog = logrus.New()
+
+func init() {
+	dest, ok := os.LookupEnv("CONJURAPI_LOG")
+	if !ok {
+		return
+	}
+
+	var (
+		out io.Writer
+		err error
+	)
+	switch dest {
+	case "stdout":
+		out = os.Stdout
+	case "stderr":
+		out = os.Stderr
+	default:
+		out, err = os.OpenFile(dest, os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			logrus.Fatalf("Failed to %s", err.Error())
+		}
+		logrus.Info("Logging to %s", dest)
+	}
+
+	ApiLog.Out = out
+	ApiLog.Level = logrus.DebugLevel
+}

--- a/conjurapi/resource.go
+++ b/conjurapi/resource.go
@@ -1,8 +1,15 @@
 package conjurapi
 
 import (
+	"encoding/json"
 	"fmt"
+
+	"github.com/cyberark/conjur-api-go/conjurapi/response"
 )
+
+type ResourceFilter struct {
+	Kind string
+}
 
 // CheckPermission determines whether the authenticated user has a specified privilege
 // on a resource.
@@ -24,4 +31,50 @@ func (c *Client) CheckPermission(resourceID, privilege string) (bool, error) {
 	} else {
 		return false, fmt.Errorf("Permission check failed with HTTP status %d", resp.StatusCode)
 	}
+}
+
+// Resource fetches a single user-visible resource by id.
+func (c *Client) Resource(resourceID string) (resource map[string]interface{}, err error) {
+	req, err := c.router.ResourceRequest(resourceID)
+	if err != nil {
+		return
+	}
+
+	resp, err := c.SubmitRequest(req)
+	if err != nil {
+		return
+	}
+
+	data, err := response.DataResponse(resp)
+	if err != nil {
+		return
+	}
+
+	resource = make(map[string]interface{})
+	err = json.Unmarshal(data, &resource)
+	return
+}
+
+// Resources fetches user-visible resources. The set of resources can
+// be limited by the given ResourceFilter. If filter is non-nil, only
+// non-zero-valued members of the filter will be applied.
+func (c *Client) Resources(filter *ResourceFilter) (resources []map[string]interface{}, err error) {
+	req, err := c.router.ResourcesRequest(filter)
+	if err != nil {
+		return
+	}
+
+	resp, err := c.SubmitRequest(req)
+	if err != nil {
+		return
+	}
+
+	data, err := response.DataResponse(resp)
+	if err != nil {
+		return
+	}
+
+	resources = make([]map[string]interface{}, 1)
+	err = json.Unmarshal(data, &resources)
+	return
 }

--- a/conjurapi/resource_test.go
+++ b/conjurapi/resource_test.go
@@ -10,15 +10,14 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestClient_CheckPermission(t *testing.T) {
-	Convey("V5", t, func() {
-		config := &Config{}
-		config.mergeEnv()
+func v5Setup() (*Client, error) {
+	config := &Config{}
+	config.mergeEnv()
 
-		apiKey := os.Getenv("CONJUR_AUTHN_API_KEY")
-		login := os.Getenv("CONJUR_AUTHN_LOGIN")
+	apiKey := os.Getenv("CONJUR_AUTHN_API_KEY")
+	login := os.Getenv("CONJUR_AUTHN_LOGIN")
 
-		policy := fmt.Sprintf(`
+	policy := fmt.Sprintf(`
 - !user alice
 
 - !variable db-password
@@ -29,55 +28,116 @@ func TestClient_CheckPermission(t *testing.T) {
   resource: !variable db-password
 `)
 
-		conjur, err := NewClientFromKey(*config, authn.LoginPair{login, apiKey})
-		So(err, ShouldBeNil)
+	conjur, err := NewClientFromKey(*config, authn.LoginPair{Login: login, APIKey: apiKey})
 
+	if err == nil {
 		conjur.LoadPolicy(
 			PolicyModePut,
 			"root",
 			strings.NewReader(policy),
 		)
+	}
 
-		Convey("Check an allowed permission", func() {
-			allowed, err := conjur.CheckPermission("cucumber:variable:db-password", "execute")
+	return conjur, err
+}
+
+func v4Setup() (*Client, error) {
+	config := &Config{
+		ApplianceURL: os.Getenv("CONJUR_V4_APPLIANCE_URL"),
+		SSLCert:      os.Getenv("CONJUR_V4_SSL_CERTIFICATE"),
+		Account:      os.Getenv("CONJUR_V4_ACCOUNT"),
+		V4:           true,
+	}
+
+	login := os.Getenv("CONJUR_V4_AUTHN_LOGIN")
+	apiKey := os.Getenv("CONJUR_V4_AUTHN_API_KEY")
+
+	return NewClientFromKey(*config, authn.LoginPair{Login: login, APIKey: apiKey})
+}
+
+func TestClient_CheckPermission(t *testing.T) {
+	checkAllowed := func(conjur *Client, id string) func() {
+		return func() {
+			allowed, err := conjur.CheckPermission(id, "execute")
 
 			So(err, ShouldBeNil)
 			So(allowed, ShouldEqual, true)
-		})
+		}
+	}
 
-		Convey("Check a permission on a non-existent resource", func() {
-			allowed, err := conjur.CheckPermission("cucumber:variable:foobar", "execute")
+	checkNonExisting := func(conjur *Client, id string) func() {
+		return func() {
+			allowed, err := conjur.CheckPermission(id, "execute")
 
 			So(err, ShouldBeNil)
 			So(allowed, ShouldEqual, false)
-		})
-	})
-	Convey("V4", t, func() {
-		config := &Config{
-			ApplianceURL: os.Getenv("CONJUR_V4_APPLIANCE_URL"),
-			SSLCert:      os.Getenv("CONJUR_V4_SSL_CERTIFICATE"),
-			Account:      os.Getenv("CONJUR_V4_ACCOUNT"),
-			V4:           true,
 		}
+	}
 
-		login := os.Getenv("CONJUR_V4_AUTHN_LOGIN")
-		apiKey := os.Getenv("CONJUR_V4_AUTHN_API_KEY")
-
-		conjur, err := NewClientFromKey(*config, authn.LoginPair{login, apiKey})
+	Convey("V5", t, func() {
+		conjur, err := v5Setup()
 		So(err, ShouldBeNil)
 
-		Convey("Check an allowed permission", func() {
-			allowed, err := conjur.CheckPermission("cucumber:variable:existent-variable-with-defined-value", "execute")
+		Convey("Check an allowed permission", checkAllowed(conjur, "cucumber:variable:db-password"))
 
+		Convey("Check a permission on a non-existent resource", checkNonExisting(conjur, "cucumber:variable:foobar"))
+	})
+	Convey("V4", t, func() {
+		conjur, err := v4Setup()
+		So(err, ShouldBeNil)
+
+		Convey("Check an allowed permission", checkAllowed(conjur, "cucumber:variable:existent-variable-with-defined-value"))
+
+		Convey("Check a permission on a non-existent resource", checkNonExisting(conjur, "cucumber:variable:foobar"))
+	})
+}
+
+func TestClient_Resources(t *testing.T) {
+	listResources := func(conjur *Client, filter *ResourceFilter) func() {
+		return func() {
+			resources, err := conjur.Resources(filter)
 			So(err, ShouldBeNil)
-			So(allowed, ShouldEqual, true)
-		})
+			So(len(resources), ShouldBeGreaterThan, 0)
+		}
+	}
 
-		Convey("Check a permission on a non-existent resource", func() {
-			allowed, err := conjur.CheckPermission("cucumber:variable:foobar", "execute")
+	Convey("V5", t, func() {
+		conjur, err := v5Setup()
+		So(err, ShouldBeNil)
 
+		Convey("Lists all resources", listResources(conjur, nil))
+		Convey("Lists resources by kind", listResources(conjur, &ResourceFilter{Kind: "variable"}))
+	})
+
+	Convey("V4", t, func() {
+		conjur, err := v4Setup()
+		So(err, ShouldBeNil)
+
+		// v4 router doesn't support it yet.
+		SkipConvey("Lists resources", listResources(conjur, nil))
+	})
+}
+
+func TestClient_Resource(t *testing.T) {
+	showResource := func(conjur *Client, id string) func() {
+		return func() {
+			_, err := conjur.Resource(id)
 			So(err, ShouldBeNil)
-			So(allowed, ShouldEqual, false)
-		})
+		}
+	}
+
+	Convey("V5", t, func() {
+		conjur, err := v5Setup()
+		So(err, ShouldBeNil)
+
+		Convey("Shows a resource", showResource(conjur, "cucumber:variable:db-password"))
+	})
+
+	Convey("V4", t, func() {
+		conjur, err := v4Setup()
+		So(err, ShouldBeNil)
+
+		// v4 router doesn't support it yet.
+		SkipConvey("Shows a resource", showResource(conjur, "cucumber:variable:existent-variable-with-defined-value"))
 	})
 }

--- a/conjurapi/response/error.go
+++ b/conjurapi/response/error.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/cyberark/conjur-api-go/conjurapi/logging"
 )
 
 type ConjurError struct {
@@ -45,7 +45,7 @@ func NewConjurError(resp *http.Response) error {
 }
 
 func (self *ConjurError) Error() string {
-	log.Debugf("self.Details: %+v, self.Message: %+v\n", self.Details, self.Message)
+	logging.ApiLog.Debugf("self.Details: %+v, self.Message: %+v\n", self.Details, self.Message)
 
 	var b strings.Builder
 

--- a/conjurapi/response/response.go
+++ b/conjurapi/response/response.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/cyberark/conjur-api-go/conjurapi/logging"
 )
 
 func readBody(resp *http.Response) ([]byte, error) {
@@ -22,7 +22,7 @@ func readBody(resp *http.Response) ([]byte, error) {
 
 func logResponse(resp *http.Response) {
 	req := resp.Request
-	log.Debugf("%d %s %s %+v", resp.StatusCode, req.Method, req.URL, req.Header)
+	logging.ApiLog.Debugf("%d %s %s %+v", resp.StatusCode, req.Method, req.URL, req.Header)
 }
 
 // DataResponse checks the HTTP status of the response. If it's less than

--- a/conjurapi/router_url.go
+++ b/conjurapi/router_url.go
@@ -1,0 +1,21 @@
+package conjurapi
+
+import (
+	"fmt"
+	"strings"
+)
+
+type routerURL string
+
+func makeRouterURL(components ...string) routerURL {
+	return routerURL(strings.Join(components, "/"))
+}
+
+func (url routerURL) withQuery(queryFormat string, queryArgs ...interface{}) routerURL {
+	query := fmt.Sprintf(queryFormat, queryArgs...)
+	return routerURL(strings.Join([]string{string(url), query}, "?"))
+}
+
+func (url routerURL) String() string {
+	return string(url)
+}

--- a/conjurapi/router_v4.go
+++ b/conjurapi/router_v4.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/cyberark/conjur-api-go/conjurapi/authn"
+	"github.com/sirupsen/logrus"
 )
 
 type RouterV4 struct {
@@ -54,6 +55,16 @@ func (r RouterV4) RotateAPIKeyRequest(roleID string) (*http.Request, error) {
 
 func (r RouterV4) LoadPolicyRequest(mode PolicyMode, policyID string, policy io.Reader) (*http.Request, error) {
 	return nil, fmt.Errorf("LoadPolicy is not supported for Conjur V4")
+}
+
+func (r RouterV4) ResourceRequest(resourceID string) (*http.Request, error) {
+	logrus.Panic("ResourceRequest not implemented yet")
+	return nil, nil
+}
+
+func (r RouterV4) ResourcesRequest(filter *ResourceFilter) (*http.Request, error) {
+	logrus.Panic("ResourcesRequest not implemented yet")
+	return nil, nil
 }
 
 func (r RouterV4) CheckPermissionRequest(resourceID, privilege string) (*http.Request, error) {

--- a/conjurapi/router_v5.go
+++ b/conjurapi/router_v5.go
@@ -15,7 +15,7 @@ type RouterV5 struct {
 }
 
 func (r RouterV5) AuthenticateRequest(loginPair authn.LoginPair) (*http.Request, error) {
-	authenticateURL := fmt.Sprintf("%s/authn/%s/%s/authenticate", r.Config.ApplianceURL, r.Config.Account, url.QueryEscape(loginPair.Login))
+	authenticateURL := makeRouterURL(r.authnURL(), url.QueryEscape(loginPair.Login), "authenticate").String()
 
 	req, err := http.NewRequest("POST", authenticateURL, strings.NewReader(loginPair.APIKey))
 	if err != nil {
@@ -27,7 +27,7 @@ func (r RouterV5) AuthenticateRequest(loginPair authn.LoginPair) (*http.Request,
 }
 
 func (r RouterV5) RotateAPIKeyRequest(roleID string) (*http.Request, error) {
-	rotateURL := fmt.Sprintf("%s/authn/%s/api_key?role=%s", r.Config.ApplianceURL, r.Config.Account, roleID)
+	rotateURL := makeRouterURL(r.authnURL(), "api_key").withQuery("role=%s", roleID).String()
 
 	return http.NewRequest(
 		"PUT",
@@ -37,11 +37,11 @@ func (r RouterV5) RotateAPIKeyRequest(roleID string) (*http.Request, error) {
 }
 
 func (r RouterV5) CheckPermissionRequest(resourceID, privilege string) (*http.Request, error) {
-	tokens := strings.SplitN(resourceID, ":", 3)
-	if len(tokens) != 3 {
-		return nil, fmt.Errorf("Resource id '%s' must be fully qualified", resourceID)
+	account, kind, id, err := parseID(resourceID)
+	if err != nil {
+		return nil, err
 	}
-	checkURL := fmt.Sprintf("%s/resources/%s/%s/%s?check=true&privilege=%s", r.Config.ApplianceURL, tokens[0], tokens[1], url.QueryEscape(tokens[2]), url.QueryEscape(privilege))
+	checkURL := makeRouterURL(r.resourcesURL(account), kind, url.QueryEscape(id)).withQuery("check=true&privilege=%s", url.QueryEscape(privilege)).String()
 
 	return http.NewRequest(
 		"GET",
@@ -53,8 +53,11 @@ func (r RouterV5) CheckPermissionRequest(resourceID, privilege string) (*http.Re
 func (r RouterV5) LoadPolicyRequest(mode PolicyMode, policyID string, policy io.Reader) (*http.Request, error) {
 	policyID = makeFullId(r.Config.Account, "policy", policyID)
 
-	tokens := strings.SplitN(policyID, ":", 3)
-	policyURL := fmt.Sprintf("%s/policies/%s/%s/%s", r.Config.ApplianceURL, tokens[0], tokens[1], url.QueryEscape(tokens[2]))
+	account, kind, id, err := parseID(policyID)
+	if err != nil {
+		return nil, err
+	}
+	policyURL := makeRouterURL(r.policiesURL(account), kind, url.QueryEscape(id)).String()
 
 	var method string
 	switch mode {
@@ -92,9 +95,14 @@ func (r RouterV5) RetrieveBatchSecretsRequest(variableIDs []string) (*http.Reque
 func (r RouterV5) RetrieveSecretRequest(variableID string) (*http.Request, error) {
 	variableID = makeFullId(r.Config.Account, "variable", variableID)
 
+	variableURL, err := r.variableURL(variableID)
+	if err != nil {
+		return nil, err
+	}
+
 	return http.NewRequest(
 		"GET",
-		r.variableURL(variableID),
+		variableURL,
 		nil,
 	)
 }
@@ -102,19 +110,47 @@ func (r RouterV5) RetrieveSecretRequest(variableID string) (*http.Request, error
 func (r RouterV5) AddSecretRequest(variableID, secretValue string) (*http.Request, error) {
 	variableID = makeFullId(r.Config.Account, "variable", variableID)
 
+	variableURL, err := r.variableURL(variableID)
+	if err != nil {
+		return nil, err
+	}
+
 	return http.NewRequest(
 		"POST",
-		r.variableURL(variableID),
+		variableURL,
 		strings.NewReader(secretValue),
 	)
 }
 
-func (r RouterV5) variableURL(variableID string) string {
-	tokens := strings.SplitN(variableID, ":", 3)
-	return fmt.Sprintf("%s/secrets/%s/%s/%s", r.Config.ApplianceURL, tokens[0], tokens[1], url.QueryEscape(tokens[2]))
+func (r RouterV5) variableURL(variableID string) (string, error) {
+	account, kind, id, err := parseID(variableID)
+	if err != nil {
+		return "", err
+	}
+	return makeRouterURL(r.secretsURL(account), kind, url.QueryEscape(id)).String(), nil
 }
 
 func (r RouterV5) batchVariableURL(variableIDs []string) string {
 	queryString := url.QueryEscape(strings.Join(variableIDs, ","))
-	return fmt.Sprintf("%s/secrets?variable_ids=%s", r.Config.ApplianceURL, queryString)
+	return makeRouterURL(r.globalSecretsURL()).withQuery("variable_ids=%s", queryString).String()
+}
+
+func (r RouterV5) authnURL() string {
+	return makeRouterURL(r.Config.ApplianceURL, "authn", r.Config.Account).String()
+}
+
+func (r RouterV5) resourcesURL(account string) string {
+	return makeRouterURL(r.Config.ApplianceURL, "resources", account).String()
+}
+
+func (r RouterV5) secretsURL(account string) string {
+	return makeRouterURL(r.Config.ApplianceURL, "secrets", account).String()
+}
+
+func (r RouterV5) globalSecretsURL() string {
+	return makeRouterURL(r.Config.ApplianceURL, "secrets").String()
+}
+
+func (r RouterV5) policiesURL(account string) string {
+	return makeRouterURL(r.Config.ApplianceURL, "policies", account).String()
 }

--- a/conjurapi/router_v5.go
+++ b/conjurapi/router_v5.go
@@ -50,6 +50,38 @@ func (r RouterV5) CheckPermissionRequest(resourceID, privilege string) (*http.Re
 	)
 }
 
+func (r RouterV5) ResourceRequest(resourceID string) (*http.Request, error) {
+	account, kind, id, err := parseID(resourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	requestURL := makeRouterURL(r.resourcesURL(account), kind, url.QueryEscape(id))
+
+	return http.NewRequest(
+		"GET",
+		requestURL.String(),
+		nil,
+	)
+}
+
+func (r RouterV5) ResourcesRequest(filter *ResourceFilter) (*http.Request, error) {
+	var query []string
+	if filter != nil {
+		if filter.Kind != "" {
+			query = append(query, fmt.Sprintf("kind=%s", url.QueryEscape(filter.Kind)))
+		}
+	}
+
+	requestURL := makeRouterURL(r.resourcesURL(r.Config.Account)).withQuery(strings.Join(query, "&"))
+
+	return http.NewRequest(
+		"GET",
+		requestURL.String(),
+		nil,
+	)
+}
+
 func (r RouterV5) LoadPolicyRequest(mode PolicyMode, policyID string, policy io.Reader) (*http.Request, error) {
 	policyID = makeFullId(r.Config.Account, "policy", policyID)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,7 @@ services:
   conjur:
     container_name: api-go-conjur
     
-    # conjur:0.9.0 has a bug that causes some test failures. Pin to
-    # the previous version till it's fixed
-    image: cyberark/conjur:0.8.1-stable
+    image: cyberark/conjur:1.1.0-stable
     
     command: server -a cucumber
     environment:


### PR DESCRIPTION
This is part of the work required for cyberark/conjur-cli-go#6.

It adds support for fetching all user-visible resources, optionally filtered by `kind`. It also adds support for fetching a single resource by id. In both cases, it unmarshals the JSON into a `map[string]interface{}` for easier examination by the caller. (Eventually, we may want to create structs for each of the resource types.)

I only added support to the v5 router here. It's not clear to me that we should continue to add functionality to the v4 router.

The API now uses an internal instance of a `logrus` logger, setting its destination using the value of the `CONJURAPI_LOG` environment variable.

To review, it's probably best to read the commits individually. Please don't squash merge them -- I worked hard to keep them distinct. If you think they're still too messy, let's discuss.