### PR TITLE
fix: v4 supports fully qualified variable ids

### DIFF
--- a/_setup.sh
+++ b/_setup.sh
@@ -26,6 +26,7 @@ api_key=$(exec_on conjur conjurctl role retrieve-key cucumber:user:admin | tr -d
 
 exec_on cuke-master bash -c 'conjur authn login -u admin -p secret'
 exec_on cuke-master conjur user create --as-group security_admin alice
+exec_on cuke-master conjur host create --as-group security_admin bob
 exec_on cuke-master conjur variable create existent-variable-with-undefined-value
 
 vars=(

--- a/conjurapi/authn_test.go
+++ b/conjurapi/authn_test.go
@@ -20,6 +20,7 @@ func TestClient_RotateAPIKey(t *testing.T) {
 
 		policy := fmt.Sprintf(`
 - !user alice
+- !host bob
 `)
 
 		conjur, err := NewClientFromKey(*config, authn.LoginPair{login, apiKey})
@@ -31,10 +32,17 @@ func TestClient_RotateAPIKey(t *testing.T) {
 			strings.NewReader(policy),
 		)
 
-		Convey("Rotate the API key of a foreign role", func() {
+		Convey("Rotate the API key of a foreign user role of kind user", func() {
 			aliceAPIKey, err := conjur.RotateAPIKey("cucumber:user:alice")
 
 			_, err = conjur.Authenticate(authn.LoginPair{"alice", string(aliceAPIKey)})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Rotate the API key of a foreign role of non-user kind", func() {
+			bobAPIKey, err := conjur.RotateAPIKey("cucumber:host:bob")
+
+			_, err = conjur.Authenticate(authn.LoginPair{"host/bob", string(bobAPIKey)})
 			So(err, ShouldBeNil)
 		})
 
@@ -64,10 +72,17 @@ func TestClient_RotateAPIKey(t *testing.T) {
 		conjur, err := NewClientFromKey(*config, authn.LoginPair{login, apiKey})
 		So(err, ShouldBeNil)
 
-		Convey("Rotate the API key of a foreign role", func() {
+		Convey("Rotate the API key of a foreign role of kind user", func() {
 			aliceAPIKey, err := conjur.RotateAPIKey("cucumber:user:alice")
 
 			_, err = conjur.Authenticate(authn.LoginPair{"alice", string(aliceAPIKey)})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Rotate the API key of a foreign role of non-user kind", func() {
+			bobAPIKey, err := conjur.RotateAPIKey("cucumber:host:bob")
+
+			_, err = conjur.Authenticate(authn.LoginPair{"host/bob", string(bobAPIKey)})
 			So(err, ShouldBeNil)
 		})
 	})

--- a/conjurapi/router_v5.go
+++ b/conjurapi/router_v5.go
@@ -27,6 +27,14 @@ func (r RouterV5) AuthenticateRequest(loginPair authn.LoginPair) (*http.Request,
 }
 
 func (r RouterV5) RotateAPIKeyRequest(roleID string) (*http.Request, error) {
+	account, _, _, err := parseID(roleID)
+	if err != nil {
+		return nil, err
+	}
+	if account != r.Config.Account {
+		return nil, fmt.Errorf("Account of '%s' must match the configured account '%s'", roleID, r.Config.Account)
+	}
+
 	rotateURL := makeRouterURL(r.authnURL(), "api_key").withQuery("role=%s", roleID).String()
 
 	return http.NewRequest(
@@ -83,9 +91,9 @@ func (r RouterV5) ResourcesRequest(filter *ResourceFilter) (*http.Request, error
 }
 
 func (r RouterV5) LoadPolicyRequest(mode PolicyMode, policyID string, policy io.Reader) (*http.Request, error) {
-	policyID = makeFullId(r.Config.Account, "policy", policyID)
+	fullPolicyID := makeFullId(r.Config.Account, "policy", policyID)
 
-	account, kind, id, err := parseID(policyID)
+	account, kind, id, err := parseID(fullPolicyID)
 	if err != nil {
 		return nil, err
 	}
@@ -112,9 +120,9 @@ func (r RouterV5) LoadPolicyRequest(mode PolicyMode, policyID string, policy io.
 
 func (r RouterV5) RetrieveBatchSecretsRequest(variableIDs []string) (*http.Request, error) {
 	fullVariableIDs := []string{}
-	for _, variable := range variableIDs {
-		variableID := makeFullId(r.Config.Account, "variable", variable)
-		fullVariableIDs = append(fullVariableIDs, variableID)
+	for _, variableID := range variableIDs {
+		fullVariableID := makeFullId(r.Config.Account, "variable", variableID)
+		fullVariableIDs = append(fullVariableIDs, fullVariableID)
 	}
 
 	return http.NewRequest(
@@ -125,9 +133,9 @@ func (r RouterV5) RetrieveBatchSecretsRequest(variableIDs []string) (*http.Reque
 }
 
 func (r RouterV5) RetrieveSecretRequest(variableID string) (*http.Request, error) {
-	variableID = makeFullId(r.Config.Account, "variable", variableID)
+	fullVariableID := makeFullId(r.Config.Account, "variable", variableID)
 
-	variableURL, err := r.variableURL(variableID)
+	variableURL, err := r.variableURL(fullVariableID)
 	if err != nil {
 		return nil, err
 	}
@@ -140,9 +148,9 @@ func (r RouterV5) RetrieveSecretRequest(variableID string) (*http.Request, error
 }
 
 func (r RouterV5) AddSecretRequest(variableID, secretValue string) (*http.Request, error) {
-	variableID = makeFullId(r.Config.Account, "variable", variableID)
+	fullVariableID := makeFullId(r.Config.Account, "variable", variableID)
 
-	variableURL, err := r.variableURL(variableID)
+	variableURL, err := r.variableURL(fullVariableID)
 	if err != nil {
 		return nil, err
 	}

--- a/conjurapi/variable_test.go
+++ b/conjurapi/variable_test.go
@@ -224,6 +224,19 @@ func TestClient_RetrieveSecret(t *testing.T) {
 		login := os.Getenv("CONJUR_V4_AUTHN_LOGIN")
 		apiKey := os.Getenv("CONJUR_V4_AUTHN_API_KEY")
 
+		Convey("Returns existent variable's defined value, given full qualified ID", func() {
+			variableIdentifier := "cucumber:variable:existent-variable-with-defined-value"
+			secretValue := "existent-variable-defined-value"
+
+			conjur, err := NewClientFromKey(*config, authn.LoginPair{login, apiKey})
+			So(err, ShouldBeNil)
+
+			obtainedSecretValue, err := conjur.RetrieveSecret(variableIdentifier)
+			So(err, ShouldBeNil)
+
+			So(string(obtainedSecretValue), ShouldEqual, secretValue)
+		})
+
 		Convey("Returns existent variable's defined value", func() {
 			variableIdentifier := "existent-variable-with-defined-value"
 			secretValue := "existent-variable-defined-value"


### PR DESCRIPTION
+ add support to v4 router for fully qualified variable ids
+ remove duplicated code by using `parseID`
+ add tests for rotating non-user API key