### PR TITLE
Allow overriding http.Client

### DIFF
--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -127,6 +127,14 @@ func NewClientFromEnvironment(config Config) (*Client, error) {
 	return nil, fmt.Errorf("Environment variables and machine identity files satisfying at least one authentication strategy must be present!")
 }
 
+func (c *Client) GetHttpClient() (*http.Client) {
+	return c.httpClient
+}
+
+func (c *Client) SetHttpClient(httpClient *http.Client) {
+	c.httpClient = httpClient
+}
+
 func (c *Client) GetConfig() (Config) {
 	return c.config
 }


### PR DESCRIPTION
adding HttpClient public property to Client, so that it can be overridden with Proxy support, custom headers/useragent & GoVCR for testing & http request playback

https://github.com/seborama/govcr