### PR TITLE
Update LoadConfig to call getHomeDir method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+* Modify configuration loading to skip options that check home dirs if there is
+  an error retrieving the home dir
+
 # [0.5.0]
 
 * Add support for passing fully qualified variable id to `RetrieveSecret` API method in v4 mode


### PR DESCRIPTION
Move the functionality to get the user's home dir out of LoadConfig, and if
the call to user.Current errors, return a blank home dir value

If there is no home dir value set, skip the netrc and conjurrc methods which
use the home dir as the base dir

Ultimately we may want to use a method to retrieve the user's home dir that is
more generally reliable, for example when [os.UserHomeDir](https://github.com/golang/go/issues/26463) is released in Go 1.12

Connected to #39 

[Jenkins build](https://jenkins.conjur.net/job/cyberark--conjur-api-go/job/fix-loadconfig-user-error/)