### PR TITLE
Added links to the new v0.6.0 release to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Initial version
 
-[Unreleased]: https://github.com/cyberark/conjur-api-go/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-api-go/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/cyberark/conjur-api-go/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/cyberark/conjur-api-go/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/cyberark/conjur-api-go/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/cyberark/conjur-api-go/compare/v0.3.0...v0.3.3


### PR DESCRIPTION
This will allow people looking at the changelog to see the changes
between 0.6.0 version and the older ones.