### PR TITLE
Measure coverage when tests run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN apk add --no-cache bash \
                        libc-dev
 
 RUN go get -u github.com/jstemmer/go-junit-report && \
-    go get -u github.com/smartystreets/goconvey
+    go get -u github.com/smartystreets/goconvey && \
+    go get -u github.com/axw/gocov/gocov && \
+    go get -u github.com/AlekSi/gocov-xml
 
 WORKDIR /conjur-api-go
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,11 +20,14 @@ pipeline {
         }
       }
     }
-    
+
     stage('Run tests') {
       steps {
         sh './test.sh'
+        sh 'mv output/c.out .'
         junit 'output/junit.xml'
+        cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'output/coverage.xml', conditionalCoverageTargets: '30, 0, 0', failUnhealthy: true, failUnstable: false, lineCoverageTargets: '30, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '30, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
+        ccCoverage("gocov", "--prefix github.com/cyberark/conjur-api-go")
       }
     }
 

--- a/test.sh
+++ b/test.sh
@@ -25,8 +25,9 @@ CONJUR_AUTHN_API_KEY="$api_key" \
   docker-compose run test \
     bash -c 'set -o pipefail;
              echo "Running tests...";
-             go test -v ./... | tee output/junit.output;
+             go test -coverprofile="output/c.out" -v ./... | tee output/junit.output;
              exit_code=$?;
              echo "Tests finished - aggregating results...";
              cat output/junit.output | go-junit-report > output/junit.xml;
+             gocov convert ./output/c.out | gocov-xml > output/coverage.xml;
              [ "$exit_code" -eq 0 ]' || failed


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
- Adds code to measure code coverage when the tests are run, archive that coverage report in Jenkins and upload the coverage data to Code Climate

### What ticket does this PR close?
Fixes #57 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation