### PR TITLE
74 We now correctly throw errors when `.conjurrc` is unparsable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Errors from YAML parsing are now breaking and visible in logs.
+  [cyberark/conjur-api-go#74](https://github.com/cyberark/conjur-api-go/issues/74)
+
 ## [0.6.0] - 2019-03-04
 ### Added
 - Converted to Golang 1.12

--- a/conjurapi/config_test.go
+++ b/conjurapi/config_test.go
@@ -165,4 +165,21 @@ netrc_path: "/path/to/netrc/file%v"
 			})
 		})
 	}
+
+	Convey("Throws errors when conjurrc is present but unparsable", t, func() {
+		badConjurrc := `
+---
+appliance_url: http://path/to/appliance
+account: some account
+cert_file: "C:\badly\escaped\path"
+`
+
+		tmpFileName, err := TempFileForTesting("TestConfigParsingErroHandling", badConjurrc)
+		defer os.Remove(tmpFileName) // clean up
+		So(err, ShouldBeNil)
+
+		config := &Config{}
+		err = config.mergeYAML(tmpFileName)
+		So(err, ShouldNotBeNil)
+	})
 }


### PR DESCRIPTION
Previously the errors were eaten and no error was thrown but now we do
both so that the user can pinpoint problematic areas quickly.

### What ticket does this PR close?
Resolves #74 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation