### PR TITLE
Update secrets batch request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Updated Go versions to 1.15
 
+### Added
+- RetrieveBatchSecretsSafe method which allows the user to specify use of the `Accept: base64`
+  header in batch retrieval requests. This allows for the retrieval of binary secrets from Conjur.
+  [cyberark/conjur-api-go#88](https://github.com/cyberark/conjur-api-go/issues/88)
+
 ## [0.6.1] - 2020-12-02
 ### Changed
 - Errors from YAML parsing are now breaking and visible in logs.

--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -36,7 +36,7 @@ type Router interface {
 	LoadPolicyRequest(mode PolicyMode, policyID string, policy io.Reader) (*http.Request, error)
 	ResourceRequest(resourceID string) (*http.Request, error)
 	ResourcesRequest(filter *ResourceFilter) (*http.Request, error)
-	RetrieveBatchSecretsRequest(variableIDs []string) (*http.Request, error)
+	RetrieveBatchSecretsRequest(variableIDs []string, base64Flag bool) (*http.Request, error)
 	RetrieveSecretRequest(variableID string) (*http.Request, error)
 	RotateAPIKeyRequest(roleID string) (*http.Request, error)
 }

--- a/conjurapi/router_v4.go
+++ b/conjurapi/router_v4.go
@@ -86,7 +86,11 @@ func (r RouterV4) AddSecretRequest(variableID, secretValue string) (*http.Reques
 	return nil, fmt.Errorf("AddSecret is not supported for Conjur V4")
 }
 
-func (r RouterV4) RetrieveBatchSecretsRequest(variableIDs []string) (*http.Request, error) {
+func (r RouterV4) RetrieveBatchSecretsRequest(variableIDs []string, base64Flag bool) (*http.Request, error) {
+	if base64Flag {
+		return nil, fmt.Errorf("Batch retrieving Base64-encoded secrets is not supported in Conjur V4")
+	}
+
 	return http.NewRequest(
 		"GET",
 		r.batchVariableURL(variableIDs),

--- a/conjurapi/router_v5.go
+++ b/conjurapi/router_v5.go
@@ -131,18 +131,28 @@ func (r RouterV5) LoadPolicyRequest(mode PolicyMode, policyID string, policy io.
 	)
 }
 
-func (r RouterV5) RetrieveBatchSecretsRequest(variableIDs []string) (*http.Request, error) {
+func (r RouterV5) RetrieveBatchSecretsRequest(variableIDs []string, base64Flag bool) (*http.Request, error) {
 	fullVariableIDs := []string{}
 	for _, variableID := range variableIDs {
 		fullVariableID := makeFullId(r.Config.Account, "variable", variableID)
 		fullVariableIDs = append(fullVariableIDs, fullVariableID)
 	}
 
-	return http.NewRequest(
+	request, err := http.NewRequest(
 		"GET",
 		r.batchVariableURL(fullVariableIDs),
 		nil,
 	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if base64Flag {
+		request.Header.Add("Accept", "base64")
+	}
+
+	return request, nil
 }
 
 func (r RouterV5) RetrieveSecretRequest(variableID string) (*http.Request, error) {
@@ -176,6 +186,7 @@ func (r RouterV5) AddSecretRequest(variableID, secretValue string) (*http.Reques
 	if err != nil {
 		return nil, err
 	}
+
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	return request, nil
 }

--- a/conjurapi/router_v5.go
+++ b/conjurapi/router_v5.go
@@ -168,11 +168,16 @@ func (r RouterV5) AddSecretRequest(variableID, secretValue string) (*http.Reques
 		return nil, err
 	}
 
-	return http.NewRequest(
+	request, err := http.NewRequest(
 		"POST",
 		variableURL,
 		strings.NewReader(secretValue),
 	)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	return request, nil
 }
 
 func (r RouterV5) variableURL(variableID string) (string, error) {

--- a/conjurapi/variable.go
+++ b/conjurapi/variable.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"encoding/json"
+	"encoding/base64"
 
 	"github.com/cyberark/conjur-api-go/conjurapi/response"
 )
@@ -14,18 +15,7 @@ import (
 //
 // The authenticated user must have execute privilege on all variables.
 func (c *Client) RetrieveBatchSecrets(variableIDs []string) (map[string][]byte, error) {
-	resp, err := c.retrieveBatchSecrets(variableIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := response.DataResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	jsonResponse := map[string]string{}
-	err = json.Unmarshal(data, &jsonResponse)
+	jsonResponse, err := c.retrieveBatchSecrets(variableIDs, false)
 	if err != nil {
 		return nil, err
 	}
@@ -33,6 +23,31 @@ func (c *Client) RetrieveBatchSecrets(variableIDs []string) (map[string][]byte, 
 	resolvedVariables := map[string][]byte{}
 	for id, value := range jsonResponse {
 		resolvedVariables[id] = []byte(value)
+	}
+
+	return resolvedVariables, nil
+}
+
+// RetrieveBatchSecretsSafe fetches values for all variables in a slice using a
+// single API call. This version of the method will automatically base64-encode
+// the secrets on the server side allowing the retrieval of binary values in
+// batch requests. Secrets are NOT base64 encoded in the returned map.
+//
+// The authenticated user must have execute privilege on all variables.
+func (c *Client) RetrieveBatchSecretsSafe(variableIDs []string) (map[string][]byte, error) {
+	jsonResponse, err := c.retrieveBatchSecrets(variableIDs, true)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedVariables := map[string][]byte{}
+	var decodedValue []byte
+	for id, value := range jsonResponse {
+		decodedValue, err = base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return nil, err
+		}
+		resolvedVariables[id] = decodedValue
 	}
 
 	return resolvedVariables, nil
@@ -63,13 +78,29 @@ func (c *Client) RetrieveSecretReader(variableID string) (io.ReadCloser, error) 
 	return response.SecretDataResponse(resp)
 }
 
-func (c *Client) retrieveBatchSecrets(variableIDs []string) (*http.Response, error) {
-	req, err := c.router.RetrieveBatchSecretsRequest(variableIDs)
+func (c *Client) retrieveBatchSecrets(variableIDs []string, base64Flag bool) (map[string]string, error) {
+	req, err := c.router.RetrieveBatchSecretsRequest(variableIDs, base64Flag)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.SubmitRequest(req)
+	resp, err := c.SubmitRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := response.DataResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonResponse := map[string]string{}
+	err = json.Unmarshal(data, &jsonResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonResponse, nil
 }
 
 func (c *Client) retrieveSecret(variableID string) (*http.Response, error) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,7 @@ services:
     image: postgres:9.3
 
   conjur:
-    image: cyberark/conjur:1.3
-
+    image: cyberark/conjur:edge
     command: server -a cucumber
     environment:
       DATABASE_URL: postgres://postgres@postgres/postgres


### PR DESCRIPTION
### What does this PR do?
Updated the Go client to have an option to use the header `Accept: base64` when making batch secret requests to Conjur. This will automatically encode all secrets in base64 before returning them, which ensures binary secrets do not cause encoding errors in Conjur.

### What ticket does this PR close?
Resolves #88

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation