### PR TITLE
Update resources logic to use the exact query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Resources method no longer sends improperly URL-encoded query strings when
+  filtering resources with the "Search" parameter. Previously, if you used a
+  "Search" value that included a slash "/", the client would return no results
+  even if the server had matching resources due to an issue with the URL-encoding.
+  [cyberark/conjur-api-go#93](https://github.com/cyberark/conjur-api-go/issues/93)
+
 ## [0.7.0] - 2021-02-10
 ### Changed
 - Updated Go versions to 1.15

--- a/conjurapi/router_url.go
+++ b/conjurapi/router_url.go
@@ -11,8 +11,12 @@ func makeRouterURL(components ...string) routerURL {
 	return routerURL(strings.Join(components, "/"))
 }
 
-func (url routerURL) withQuery(queryFormat string, queryArgs ...interface{}) routerURL {
+func (url routerURL) withFormattedQuery(queryFormat string, queryArgs ...interface{}) routerURL {
 	query := fmt.Sprintf(queryFormat, queryArgs...)
+	return routerURL(strings.Join([]string{string(url), query}, "?"))
+}
+
+func (url routerURL) withQuery(query string) routerURL {
 	return routerURL(strings.Join([]string{string(url), query}, "?"))
 }
 

--- a/conjurapi/router_v5.go
+++ b/conjurapi/router_v5.go
@@ -36,7 +36,7 @@ func (r RouterV5) RotateAPIKeyRequest(roleID string) (*http.Request, error) {
 		return nil, fmt.Errorf("Account of '%s' must match the configured account '%s'", roleID, r.Config.Account)
 	}
 
-	rotateURL := makeRouterURL(r.authnURL(), "api_key").withQuery("role=%s", roleID).String()
+	rotateURL := makeRouterURL(r.authnURL(), "api_key").withFormattedQuery("role=%s", roleID).String()
 
 	return http.NewRequest(
 		"PUT",
@@ -50,7 +50,7 @@ func (r RouterV5) CheckPermissionRequest(resourceID, privilege string) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	checkURL := makeRouterURL(r.resourcesURL(account), kind, url.QueryEscape(id)).withQuery("check=true&privilege=%s", url.QueryEscape(privilege)).String()
+	checkURL := makeRouterURL(r.resourcesURL(account), kind, url.QueryEscape(id)).withFormattedQuery("check=true&privilege=%s", url.QueryEscape(privilege)).String()
 
 	return http.NewRequest(
 		"GET",
@@ -201,7 +201,7 @@ func (r RouterV5) variableURL(variableID string) (string, error) {
 
 func (r RouterV5) batchVariableURL(variableIDs []string) string {
 	queryString := url.QueryEscape(strings.Join(variableIDs, ","))
-	return makeRouterURL(r.globalSecretsURL()).withQuery("variable_ids=%s", queryString).String()
+	return makeRouterURL(r.globalSecretsURL()).withFormattedQuery("variable_ids=%s", queryString).String()
 }
 
 func (r RouterV5) authnURL() string {


### PR DESCRIPTION
### What does this PR do?
Previously the constructed query string for the Resources method was
additionally passed through fmt.Sprintf, which broke the valid URL-encoding in
the query strings. To resolve this, most methods use a new method
"withFormattedQuery" that continues to leverage Sprintf to interpolate values
into strings, but Resources just appends the query string directly to the URL.

### What ticket does this PR close?
Resolves #93

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation