### PR TITLE
Updated the batch secrets retrieval header param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Changed RetrieveBatchSecretsSafe method to use the `Accept-Encoding` header from `Accept`
-  [cyberark/conjur-api-go#99](https://github.com/cyberark/conjur-api-go/issues/74)
+  [cyberark/conjur-api-go#99](https://github.com/cyberark/conjur-api-go/issues/99)
 
 ## [0.7.0] - 2021-02-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed RetrieveBatchSecretsSafe method to use the `Accept-Encoding` header from `Accept`
+  [cyberark/conjur-api-go#99](https://github.com/cyberark/conjur-api-go/issues/74)
 
 ## [0.7.0] - 2021-02-10
 ### Changed

--- a/conjurapi/router_v5.go
+++ b/conjurapi/router_v5.go
@@ -149,7 +149,7 @@ func (r RouterV5) RetrieveBatchSecretsRequest(variableIDs []string, base64Flag b
 	}
 
 	if base64Flag {
-		request.Header.Add("Accept", "base64")
+		request.Header.Add("Accept-Encoding", "base64")
 	}
 
 	return request, nil


### PR DESCRIPTION
### What does this PR do?
The header parameter used to set secrets to base64 encode
on batch retrieval was changed from Accept to Accept-Encoding
in Conjur, this change reflects that.

Resolves #99

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation