### PR TITLE
New error state when conjur cant handle encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   instead of `Accept`, consistent with [recent updates on the Conjur server](https://github.com/cyberark/conjur/pull/2065).
   [cyberark/conjur-api-go#99](https://github.com/cyberark/conjur-api-go/issues/99)
 
+### Added
+- New check in RetrieveBatchSecretSafe method which will return an error if the `Content-Type` header
+  is not set in the response (this indicates Conjur is out of date with the client).
+  [cyberark/conjur-api-go#104](https://github.com/cyberark/conjur-api-go/issues/104)
+
 ## [0.7.1] - 2021-03-01
 ### Fixed
 - Resources method no longer sends improperly URL-encoded query strings when

--- a/conjurapi/variable.go
+++ b/conjurapi/variable.go
@@ -3,6 +3,7 @@ package conjurapi
 import (
 	"io"
 	"net/http"
+	"errors"
 
 	"encoding/json"
 	"encoding/base64"
@@ -92,6 +93,13 @@ func (c *Client) retrieveBatchSecrets(variableIDs []string, base64Flag bool) (ma
 	data, err := response.DataResponse(resp)
 	if err != nil {
 		return nil, err
+	}
+
+	if base64Flag && resp.Header.Get("Content-Encoding") != "base64" {
+		return nil, errors.New(
+			"Conjur response is not Base64-encoded. " +
+			"The Conjur version may not be compatible with this function - " +
+			"try using RetrieveBatchSecrets instead." )
 	}
 
 	jsonResponse := map[string]string{}


### PR DESCRIPTION
### What does this PR do?
Added a check in the `ReturnBatchSecretsSafe` method which will return an error if the method is used and the proper `Content-Encoding` header is not returned. 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation