### PR TITLE
Add support for ResourcesRequest to v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New check in RetrieveBatchSecretSafe method which will return an error if the `Content-Type` header
   is not set in the response (this indicates Conjur is out of date with the client).
   [cyberark/conjur-api-go#104](https://github.com/cyberark/conjur-api-go/issues/104)
+- ResourcesRequest is now supported for v4 conjur instances.
 
 ## [0.7.1] - 2021-03-01
 ### Fixed

--- a/conjurapi/resource_test.go
+++ b/conjurapi/resource_test.go
@@ -136,8 +136,12 @@ func TestClient_Resources(t *testing.T) {
 			conjur, err := v4Setup()
 			So(err, ShouldBeNil)
 
-			// v4 router doesn't support it yet.
-			SkipConvey("Lists resources", listResources(conjur, nil, 1))
+			Convey("Lists all resources", listResources(conjur, nil, 35))
+			Convey("Lists resources by kind", listResources(conjur, &ResourceFilter{Kind: "variable"}, 16))
+			Convey("Lists resources that start with db", listResources(conjur, &ResourceFilter{Search: "db"}, 1))
+			Convey("Lists variables that start with prod", listResources(conjur, &ResourceFilter{Search: "authn-tv/api-key", Kind: "variable"}, 1))
+			Convey("Lists resources and limit result to 1", listResources(conjur, &ResourceFilter{Limit: 1}, 1))
+			Convey("Lists resources after the first", listResources(conjur, &ResourceFilter{Offset: 1}, 10))
 		})
 	}
 }


### PR DESCRIPTION
This adds support for the ResourcesRequest calls to v4 conjur
servers

### What does this PR do?
- Adds support for listing resources from v4 conjur instances
- https://conjur.docs.apiary.io/#reference/resource/listsearch/list-or-search-for-resources covers the api for v4 for this endpoint.  These changes don't fully implement path or path_text, but does implement kind, search, limit and offset

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation