### PR TITLE
Fix tests: Batch retrieval failure now returns 406

### DIFF
--- a/conjurapi/variable_test.go
+++ b/conjurapi/variable_test.go
@@ -172,7 +172,7 @@ func TestClient_RetrieveSecret(t *testing.T) {
 				So(err, ShouldNotBeNil)
 				So(err.Error(), ShouldContainSubstring, "Issue encoding secret into JSON format")
 				conjurError := err.(*response.ConjurError)
-				So(conjurError.Code, ShouldEqual, 500)
+				So(conjurError.Code, ShouldEqual, 406)
 			})
 		})
 


### PR DESCRIPTION
### What does this PR do?

Conjur has changed behavior, a failure to encode batch secrets results in a 406 status code instead of the previous 500, se https://github.com/cyberark/conjur/pull/2124.

This PR updates the tests to reflect the new format.

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation