### PR TITLE
Run tests in sequence vs parallel to deflake v4 tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,23 +21,20 @@ pipeline {
       }
     }
 
-    stage('Run tests') {
-      parallel {
-        stage("Golang 1.14") {
-          steps {
-              sh './bin/test.sh 1.14'
-              junit 'output/1.14/junit.xml'
-          }
-        }
-        stage("Golang 1.15") {
-          steps {
-              sh './bin/test.sh 1.15'
-              junit 'output/1.15/junit.xml'
-              cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'output/1.15/coverage.xml', conditionalCoverageTargets:'30, 0, 0', failUnhealthy: true, failUnstable: false, lineCoverageTargets: '30, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '30, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
-              sh 'cp output/1.15/c.out .'
-              ccCoverage("gocov", "--prefix github.com/cyberark/conjur-api-go")
-          }
-        }
+    stage('Run tests: Golang 1.14') {
+      steps {
+        sh './bin/test.sh 1.14'
+        junit 'output/1.14/junit.xml'
+      }
+    }
+
+    stage('Run tests: Golang 1.15') {
+      steps {
+        sh './bin/test.sh 1.15'
+        junit 'output/1.15/junit.xml'
+        cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'output/1.15/coverage.xml', conditionalCoverageTargets:'30, 0, 0', failUnhealthy: true, failUnstable: false, lineCoverageTargets: '30, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '30, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
+        sh 'cp output/1.15/c.out .'
+        ccCoverage("gocov", "--prefix github.com/cyberark/conjur-api-go")
       }
     }
 


### PR DESCRIPTION
### What does this PR do?
The v4 tests have been flaky. They seem to consistently pass when run in sequence which suggests there might be some contention during parallel runs. 

### What ticket does this PR close?
Resolves https://github.com/cyberark/conjur-api-go/issues/108

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation