### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ and will run the tests in a `golang:1.14` container
 Supported arguments are `1.14` and `1.15`, with the
 default being `1.15` if no argument is given.
 
-To run just the tests against just the OSS version of Conjur, run:
+To run just the tests against just the Conjur Open Source, run:
 
 ```shell
 export TEST_VERSION="oss"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Programmatic Golang access to the Conjur API.
 
-## Using conjur-api-go with Conjur OSS 
+## Using conjur-api-go with Conjur Open Source 
 
-Are you using this project with [Conjur OSS](https://github.com/cyberark/conjur)? Then we 
+Are you using this project with [Conjur Open Source](https://github.com/cyberark/conjur)? Then we 
 **strongly** recommend choosing the version of this project to use from the latest [Conjur OSS 
 suite release](https://docs.conjur.org/Latest/en/Content/Overview/Conjur-OSS-Suite-Overview.html). 
 Conjur maintainers perform additional testing on the suite release versions to ensure 


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
