### PR TITLE
Fix token authenticator tests

### DIFF
--- a/bin/start-conjur.sh
+++ b/bin/start-conjur.sh
@@ -18,16 +18,16 @@ main() {
   fi
 
   announce "Pulling images..."
-  docker-compose -p $COMPOSE_PROJECT_NAME pull ${images[@]} "postgres" "cli5"
+  docker-compose pull ${images[@]} "postgres" "cli5"
   echo "Done!"
 
   announce "Building images..."
-  docker-compose -p $COMPOSE_PROJECT_NAME build ${images[@]} "postgres"
+  docker-compose build ${images[@]} "postgres"
   echo "Done!"
 
   announce "Starting Conjur environment..."
-  export CONJUR_DATA_KEY="$(docker-compose -p $COMPOSE_PROJECT_NAME run -T --no-deps conjur data-key generate)"
-  docker-compose -p $COMPOSE_PROJECT_NAME up --no-deps -d ${images[@]} "postgres"
+  export CONJUR_DATA_KEY="$(docker-compose run -T --no-deps conjur data-key generate)"
+  docker-compose up --no-deps -d ${images[@]} "postgres"
   echo "Done!"
 
   announce "Waiting for conjur to start..."

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -10,7 +10,7 @@ export GO_VERSION="${1:-"1.16"}"
 source ./start-conjur.sh
 
 announce "Building test containers..."
-docker-compose -p $COMPOSE_PROJECT_NAME build "test-$GO_VERSION"
+docker-compose build "test-$GO_VERSION"
 echo "Done!"
 
 # generate output folder locally, if needed
@@ -19,13 +19,13 @@ mkdir -p $output_dir
 
 failed() {
   announce "TESTS FAILED"
-  docker logs "$(docker-compose -p $COMPOSE_PROJECT_NAME ps -q cuke-master)"
+  docker logs "$(docker-compose ps -q cuke-master)"
   exit 1
 }
 
 # Golang container version to use: `1.16` or `1.17`
 announce "Running tests for Go version: $GO_VERSION...";
-docker-compose -p $COMPOSE_PROJECT_NAME run \
+docker-compose run \
   -e CONJUR_AUTHN_API_KEY \
   -e CONJUR_V4_AUTHN_API_KEY \
   -e CONJUR_V4_SSL_CERTIFICATE \

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -15,7 +15,7 @@ function announce() {
 exec_on() {
   local container="$1"; shift
 
-  docker exec "$(docker-compose -p $COMPOSE_PROJECT_NAME ps -q $container)" "$@"
+  docker exec "$(docker-compose ps -q $container)" "$@"
 }
 
 oss_only(){
@@ -23,5 +23,5 @@ oss_only(){
 }
 
 function teardown {
-  docker-compose -p $COMPOSE_PROJECT_NAME down -v
+  docker-compose down -v
 }

--- a/conjurapi/authn/token_file_authenticator.go
+++ b/conjurapi/authn/token_file_authenticator.go
@@ -11,6 +11,7 @@ type TokenFileAuthenticator struct {
 	MaxWaitTime time.Duration
 }
 
+//  TODO: is this implementation concurrent ?
 func (a *TokenFileAuthenticator) RefreshToken() ([]byte, error) {
 	maxWaitTime := a.MaxWaitTime
 	var timeout <-chan time.Time

--- a/conjurapi/authn/token_file_authenticator_test.go
+++ b/conjurapi/authn/token_file_authenticator_test.go
@@ -1,103 +1,139 @@
 package authn
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTokenFileAuthenticator_RefreshToken(t *testing.T) {
-	t.Run("Given existent token filename", func(t *testing.T) {
-		token_file, _ := ioutil.TempFile("", "existent-token-file")
-		token_file_name := token_file.Name()
-		token_file_contents := "token-from-file-contents"
-		token_file.Write([]byte(token_file_contents))
-		token_file.Close()
-		defer os.Remove(token_file_name)
+func ensureWriteFile(filepath, filecontents string) {
+	var prevModTime time.Time
 
-		t.Run("Return the token from the file", func(t *testing.T) {
-			authenticator := TokenFileAuthenticator{
-				TokenFile: token_file_name,
+	info, err := os.Stat(filepath)
+	// Panic for any error that is not! NotExist
+	if err != nil && !os.IsNotExist(err) {
+		panic(err)
+	}
+
+	// Register the previous ModTime, otherwise there is no previous file so fall back to a second before this is
+	if err != nil {
+		prevModTime = info.ModTime()
+	} else {
+		prevModTime = time.Now().Add(-time.Second)
+	}
+
+	err = ioutil.WriteFile(filepath, []byte(filecontents), 0600)
+	if err != nil {
+		panic(err)
+	}
+
+	timeout := time.After(10 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	for {
+		select {
+		// Timeout after 10 seconds. Clearly there's something wrong with i/o
+		case <-timeout:
+			err := fmt.Errorf("ensureWriteFile timed out.")
+
+			panic(err)
+		// Return only if the current ModTime is greater than the previous ModTime
+		case <-ticker.C:
+			info, err := os.Stat(filepath)
+			if err != nil || !info.ModTime().After(prevModTime) {
+				continue
 			}
 
-			token, err := authenticator.RefreshToken()
+			return
+		}
+	}
+}
 
-			assert.NoError(t, err)
-			assert.Equal(t, "token-from-file-contents", string(token))
-		})
-	})
-
-	t.Run("Given an eventually existent token filename", func(t *testing.T) {
+func TestTokenFileAuthenticator_RefreshToken(t *testing.T) {
+	t.Run("Retrieve existent token file", func(t *testing.T) {
 		token_file, _ := ioutil.TempFile("", "existent-token-file")
 		token_file_name := token_file.Name()
+		defer os.Remove(token_file_name)
 
 		token_file_contents := "token-from-file-contents"
-		os.Remove(token_file_name)
+		ensureWriteFile(token_file_name, token_file_contents)
+
+		authenticator := TokenFileAuthenticator{
+			MaxWaitTime: 1 * time.Second,
+			TokenFile:   token_file_name,
+		}
+
+		token, err := authenticator.RefreshToken()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "token-from-file-contents", string(token))
+	})
+
+	t.Run("Retrieve eventually existent token file", func(t *testing.T) {
+		token_dir, _ := ioutil.TempDir("", "existent-token-file")
+		token_file_name := path.Join(token_dir, "token")
+		defer os.RemoveAll(token_dir)
+
+		token_file_contents := "token-from-file-contents"
 		go func() {
 			ioutil.WriteFile(token_file_name, []byte(token_file_contents), 0600)
 		}()
 		defer os.Remove(token_file_name)
 
-		t.Run("Return the token from the file", func(t *testing.T) {
-			authenticator := TokenFileAuthenticator{
-				TokenFile:   token_file_name,
-				MaxWaitTime: 500 * time.Millisecond,
-			}
+		authenticator := TokenFileAuthenticator{
+			TokenFile:   token_file_name,
+			MaxWaitTime: 10 * time.Second, // The write takes place in a go routine so we need to account for slow i/o
+		}
 
-			token, err := authenticator.RefreshToken()
+		token, err := authenticator.RefreshToken()
 
-			assert.NoError(t, err)
-			assert.Equal(t, "token-from-file-contents", string(token))
-		})
+		assert.NoError(t, err)
+		assert.Equal(t, "token-from-file-contents", string(token))
 	})
 
-	t.Run("Given a non-existent token filename", func(t *testing.T) {
+	t.Run("Times out on never-existent token file", func(t *testing.T) {
 		token_file := "/path/to/non-existent-token-file"
 
-		t.Run("Return nil with error", func(t *testing.T) {
-			authenticator := TokenFileAuthenticator{
-				TokenFile: token_file,
-			}
+		authenticator := TokenFileAuthenticator{
+			TokenFile:   token_file,
+			MaxWaitTime: 10 * time.Millisecond, // Something non-zero, since zero means immediate failure
+		}
 
-			token, err := authenticator.RefreshToken()
+		token, err := authenticator.RefreshToken()
 
-			assert.Nil(t, token)
-			assert.Error(t, err)
-			assert.Equal(t, "Operation waitForTextFile timed out.", err.Error())
-		})
+		assert.Nil(t, token)
+		assert.Error(t, err)
+		assert.Equal(t, "Operation waitForTextFile timed out.", err.Error())
 	})
 }
 
 func TestTokenFileAuthenticator_NeedsTokenRefresh(t *testing.T) {
-	t.Run("Given existent token filename", func(t *testing.T) {
+	t.Run("Token refresh needed after updates", func(t *testing.T) {
 		token_file, _ := ioutil.TempFile("", "existent-token-file")
 		token_file_name := token_file.Name()
-		token_file_contents := "token-from-file-contents"
-		token_file.Write([]byte(token_file_contents))
 		defer os.Remove(token_file_name)
 
-		t.Run("Return true for recently modified file", func(t *testing.T) {
-			authenticator := TokenFileAuthenticator{
-				TokenFile: token_file_name,
-			}
-			authenticator.RefreshToken()
+		ensureWriteFile(token_file_name, "token-from-file-contents")
 
-			time.Sleep(1000 * time.Millisecond)
-			token_file.Write([]byte("recent modification"))
+		authenticator := TokenFileAuthenticator{
+			TokenFile:   token_file_name,
+			MaxWaitTime: 1 * time.Second,
+		}
 
-			assert.True(t, authenticator.NeedsTokenRefresh())
-		})
+		// Read
+		_, err := authenticator.RefreshToken()
+		assert.NoError(t, err)
 
-		t.Run("Return false for unmodified file", func(t *testing.T) {
-			authenticator := TokenFileAuthenticator{
-				TokenFile: token_file_name,
-			}
-			authenticator.RefreshToken()
+		// Return false for unmodified file
+		assert.False(t, authenticator.NeedsTokenRefresh())
 
-			assert.False(t, authenticator.NeedsTokenRefresh())
-		})
+		ensureWriteFile(token_file_name, "recent modification")
+
+		// Return true for modified file
+		assert.True(t, authenticator.NeedsTokenRefresh())
 	})
 }


### PR DESCRIPTION
### Desired Outcome

Fix flaky token authenticator tests. Running `while true; do go test -count=1 -v ./...; done` should result in a sequence of passing tests :)

### Implemented Changes

1. Introduce and use `ensureWriteFile`, a utility function that returns only when the file's modtime has been updated. The guarantees of normal write functions breakdown under unpredictable disk i/o performance (e.g. when running in Docker)... Upon further reflection, I'm not sure these guarantees exist at all when modtime is concerned, see [article](https://www.gnu.org/software/coreutils/manual/html_node/File-timestamps.html#:~:text=For%20efficiency%20reasons,mtimes%20and%20ctimes)
2. Deduplicate COMPOSE_PROJECT_NAME envvar and CLI flag

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
