### PR TITLE
Update Dockerfile base image to go 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update Dockerfile to use Go 1.17 base image
+  [cyberark/conjur-api-go#126](https://github.com/cyberark/conjur-api-go/pull/126)
 
 ## [0.8.1] - 2021-12-16
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE="golang:1.16"
+ARG FROM_IMAGE="golang:1.17"
 FROM ${FROM_IMAGE}
 MAINTAINER Conjur Inc.
 


### PR DESCRIPTION
Updates the base image in the repo Dockerfile to use Go 1.17 in keeping with the earlier upgrade we did. 
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>
