### PR TITLE
Disable cobertura ratcheting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,18 @@ pipeline {
       steps {
         sh './bin/test.sh 1.16'
         junit 'output/1.16/junit.xml'
-        cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'output/1.16/coverage.xml', conditionalCoverageTargets:'30, 0, 0', failUnhealthy: true, failUnstable: false, lineCoverageTargets: '30, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '30, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
+        cobertura autoUpdateHealth: false,
+                  autoUpdateStability: false,
+                  coberturaReportFile: 'output/1.16/coverage.xml',
+                  conditionalCoverageTargets: '30, 0, 0',
+                  failUnhealthy: true,
+                  failUnstable: false,
+                  lineCoverageTargets: '30, 0, 0',
+                  maxNumberOfBuilds: 0,
+                  methodCoverageTargets: '30, 0, 0',
+                  onlyStable: false,
+                  sourceEncoding: 'ASCII',
+                  zoomCoverageChart: false
         sh 'cp output/1.16/c.out .'
         ccCoverage("gocov", "--prefix github.com/cyberark/conjur-api-go")
       }


### PR DESCRIPTION
The automatic adjustment of coverage thresholds is currently leading to some
unexpected and inconvenient build failures, often on commits that only include
changes to non-code files. Disable it for now.