### PR TITLE
Native support JWT authn for Gitlab CICD Pipelines and optinally pass …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- New `CONJUR_AUTHN_JWT_HOST_ID` environment variable for authn-jwt [cyberark/conjur-api-go#130](https://github.com/cyberark/conjur-api-go/pull/130)
+
 ## [0.9.0] - 2022-02-20
 ### Changed
 - Update Dockerfile to use Go 1.17 base image

--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -148,7 +149,13 @@ func NewClientFromEnvironment(config Config) (*Client, error) {
 			httpClient = &http.Client{Timeout: time.Second * 10}
 		}
 
-		authnJwtUrl := makeRouterURL(config.ApplianceURL, "authn-jwt", authnJwtServiceID, config.Account, "authenticate").String()
+		authnJwtHostID := os.Getenv("CONJUR_AUTHN_JWT_HOST_ID")
+		authnJwtUrl := ""
+		if authnJwtHostID != "" {
+			authnJwtUrl = makeRouterURL(config.ApplianceURL, "authn-jwt", authnJwtServiceID, config.Account, "authenticate").String()
+		} else {
+			authnJwtUrl = makeRouterURL(config.ApplianceURL, "authn-jwt", authnJwtServiceID, config.Account, url.PathEscape(authnJwtHostID), "authenticate").String()
+		}
 
 		req, err := http.NewRequest("POST", authnJwtUrl, strings.NewReader(jwtTokenString))
 		if err != nil {


### PR DESCRIPTION
…a hostId for JWT based authn

### Desired Outcome

To use Conjur in Gitlab CICD pipelines Summon is a handy tool. But it requires nasty curl-based JWT authentication call for retrieving an access token, which then has to be passed via file to Summon. Summon should simply make use of the JWT token already present in Gitlab. Following the latest Summon enhancements for JWT authentication (supporting kubernetes JWT only), this feature shall be enhanced to support Gitlab CICD Runners.
In addition to the raw authN-functionality Summon JWT authentication shall support passing a HostID in the AuthN request to seperate Secrets for different pipeline environments (dev/test/prod).

### Implemented Changes
Add the env variable CONJUR_AUTHN_JWT_SERVICE, which supports the values 'kubernets' and 'gitlab' and reads the JWT token in the native way required by the service.
Use the env variable CONJUR_AUTHN_JWT_SERVICE_ID to specify the authenticator's service-id (as is at the moment).
Add env-variable CONJUR_AUTHN_JWT_HOST_ID to pass the host-id for JWT authN.

Attention: The code neither compiled nor tested, due to conjur-api-go build errors regarding a missing cuke-master image.
ERROR: for cuke-master  Get "https://registry2.itci.conjur.net/v2/": net/http: request canceled while waiting for connection
### Connected Issue/Story

Resolves - no GitHub issue at the moment.

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ x] The CHANGELOG needs to be updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ x] This PR requires new unit and integration tests to go with the code
  changes. These are not implemented within this PR as all conjur-api-go builds fail dur to an unavailable image.
- [ ] The changes in this PR do not require tests

#### Documentation

- [x ] Docs (`README`s) needs to be updated if this enhancement gets accepted. 
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and needs to be reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [x ] Security architect needs to review the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
