### PR TITLE
Remove Golang 1.16 from CI, replace with 1.18

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,13 +13,13 @@ test:
   artifacts:
     untracked: true
     reports:
-      junit: output/junit-1.16.xml
+      junit: output/junit-1.17.xml
     when: always
   script:
     - apk add --no-cache py-pip
     - pip install docker-compose
     - export TEST_VERSION=oss
-    - ./test.sh 1.16
+    - ./test.sh 1.17
   only:
     - branches
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,14 +34,14 @@ and will run all tests.
 
 To run the tests against a specific version of Golang, you can run the following:
 ```shell
-./bin/test.sh 1.16
+./bin/test.sh 1.17
 ```
 
 This will spin up a containerized Conjur environment and build the test containers,
-and will run the tests in a `golang:1.16` container
+and will run the tests in a `golang:1.17` container
 
-Supported arguments are `1.16` and `1.17`, with the
-default being `1.16` if no argument is given.
+Supported arguments are `1.17` and `1.18`, with the
+default being `1.17` if no argument is given.
 
 To run just the tests against just the Conjur Open Source, run:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN apt update -y && \
                    less \
                    libc-dev
 
-RUN go get -u github.com/jstemmer/go-junit-report && \
-    go get -u github.com/axw/gocov/gocov && \
-    go get -u github.com/AlekSi/gocov-xml
+RUN go install github.com/jstemmer/go-junit-report@latest && \
+    go install github.com/axw/gocov/gocov@latest && \
+    go install github.com/AlekSi/gocov-xml@latest
 
 WORKDIR /conjur-api-go
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,20 +21,20 @@ pipeline {
       }
     }
 
+    stage('Run tests: Golang 1.18') {
+      steps {
+        sh './bin/test.sh 1.18'
+        junit 'output/1.18/junit.xml'
+      }
+    }
+
     stage('Run tests: Golang 1.17') {
       steps {
         sh './bin/test.sh 1.17'
         junit 'output/1.17/junit.xml'
-      }
-    }
-
-    stage('Run tests: Golang 1.16') {
-      steps {
-        sh './bin/test.sh 1.16'
-        junit 'output/1.16/junit.xml'
         cobertura autoUpdateHealth: false,
                   autoUpdateStability: false,
-                  coberturaReportFile: 'output/1.16/coverage.xml',
+                  coberturaReportFile: 'output/1.17/coverage.xml',
                   conditionalCoverageTargets: '30, 0, 0',
                   failUnhealthy: true,
                   failUnstable: false,
@@ -44,7 +44,7 @@ pipeline {
                   onlyStable: false,
                   sourceEncoding: 'ASCII',
                   zoomCoverageChart: false
-        sh 'cp output/1.16/c.out .'
+        sh 'cp output/1.17/c.out .'
         ccCoverage("gocov", "--prefix github.com/cyberark/conjur-api-go")
       }
     }

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
+   Copyright (c) 2022 CyberArk Software Ltd. All rights reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ questions, please contact us on [Discourse](https://discuss.cyberarkcommons.org/
 
 The `conjur-api-go` has been tested against the following Go versions:
 
-    - 1.16
     - 1.17
+    - 1.18
 
 ## Installation
 
@@ -117,6 +117,6 @@ guide][contrib].
 
 ## License
 
-Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
+Copyright (c) 2022 CyberArk Software Ltd. All rights reserved.
 
 This repository is licensed under Apache License 2.0 - see [`LICENSE`](LICENSE) for more details.

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")"
 . ./utils.sh
 
 export COMPOSE_PROJECT_NAME="conjurapigo_$(openssl rand -hex 3)"
-export GO_VERSION="${1:-"1.16"}"
+export GO_VERSION="${1:-"1.17"}"
 
 # Spin up Conjur environment
 source ./start-conjur.sh
@@ -23,7 +23,7 @@ failed() {
   exit 1
 }
 
-# Golang container version to use: `1.16` or `1.17`
+# Golang container version to use: `1.17` or `1.18`
 announce "Running tests for Go version: $GO_VERSION...";
 docker-compose run \
   -e CONJUR_AUTHN_API_KEY \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,32 +26,6 @@ services:
     ports:
       - 443
 
-  test-1.16:
-    build:
-      context: .
-      args:
-        FROM_IMAGE: "golang:1.16"
-    ports:
-      - 8080
-    depends_on:
-      - conjur
-    volumes:
-      - ./output:/conjur-api-go/output
-    environment:
-      CONJUR_DATA_KEY:
-      CONJUR_APPLIANCE_URL: http://conjur
-      CONJUR_ACCOUNT: cucumber
-      CONJUR_AUTHN_LOGIN: admin
-      CONJUR_AUTHN_API_KEY:
-      CONJUR_V4_APPLIANCE_URL: https://cuke-master/api
-      CONJUR_V4_HEALTH_URL: https://cuke-master/health
-      CONJUR_V4_ACCOUNT: cucumber
-      CONJUR_V4_AUTHN_LOGIN: admin
-      CONJUR_V4_AUTHN_API_KEY:
-      CONJUR_V4_SSL_CERTIFICATE:
-      TEST_VERSION:
-      GO_VERSION:
-
   test-1.17:
     build:
       context: .
@@ -78,11 +52,37 @@ services:
       TEST_VERSION:
       GO_VERSION:
 
+  test-1.18:
+    build:
+      context: .
+      args:
+        FROM_IMAGE: "golang:1.18"
+    ports:
+      - 8080
+    depends_on:
+      - conjur
+    volumes:
+      - ./output:/conjur-api-go/output
+    environment:
+      CONJUR_DATA_KEY:
+      CONJUR_APPLIANCE_URL: http://conjur
+      CONJUR_ACCOUNT: cucumber
+      CONJUR_AUTHN_LOGIN: admin
+      CONJUR_AUTHN_API_KEY:
+      CONJUR_V4_APPLIANCE_URL: https://cuke-master/api
+      CONJUR_V4_HEALTH_URL: https://cuke-master/health
+      CONJUR_V4_ACCOUNT: cucumber
+      CONJUR_V4_AUTHN_LOGIN: admin
+      CONJUR_V4_AUTHN_API_KEY:
+      CONJUR_V4_SSL_CERTIFICATE:
+      TEST_VERSION:
+      GO_VERSION:
+
   dev:
     build:
       context: .
       args:
-        FROM_IMAGE: "golang:1.16"
+        FROM_IMAGE: "golang:1.17"
     ports:
       - 8080
     depends_on:


### PR DESCRIPTION
### Desired Outcome

Golang 1.16 support was removed in cyberark/conjur-api-go#121 but remained in the CI. This PR removes it and adds 1.18 as an additional tested version

### Implemented Changes

- Removed support for testing against Golang 1.16
- Removed stated support of Golang 1.16 from README
- Removed CI steps that tested with Golang 1.16
- Added a new CI step that tests with Golang 1.18
- Updated copyright year from 2020 to 2022

### Connected Issue/Story

N/A

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
