### PR TITLE
Fix bug with JWT env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed bug with `CONJUR_AUTHN_JWT_HOST_ID` environment variable not being read
+  [cyberark/conjur-api-go#136](https://github.com/cyberark/conjur-api-go/pull/136)
+
 ## [0.10.1] - 2022-06-14
 ### Changed
 - Update testify to 1.7.2

--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -152,9 +152,9 @@ func NewClientFromEnvironment(config Config) (*Client, error) {
 		authnJwtHostID := os.Getenv("CONJUR_AUTHN_JWT_HOST_ID")
 		authnJwtUrl := ""
 		if authnJwtHostID != "" {
-			authnJwtUrl = makeRouterURL(config.ApplianceURL, "authn-jwt", authnJwtServiceID, config.Account, "authenticate").String()
-		} else {
 			authnJwtUrl = makeRouterURL(config.ApplianceURL, "authn-jwt", authnJwtServiceID, config.Account, url.PathEscape(authnJwtHostID), "authenticate").String()
+		} else {
+			authnJwtUrl = makeRouterURL(config.ApplianceURL, "authn-jwt", authnJwtServiceID, config.Account, "authenticate").String()
 		}
 
 		req, err := http.NewRequest("POST", authnJwtUrl, strings.NewReader(jwtTokenString))


### PR DESCRIPTION
Fix bug introduced by #130. Bug reported by @matthiasjung.

In https://github.com/cyberark/conjur-api-go/pull/130 we added support for a new env var for authn-jwt, CONJUR_AUTHN_JWT_HOST_ID. We used an if statement to check whether this env var was set, but we seem to have accidentally switched what should have been an `if authnJwtHostID != ""` => _consume variable_ to instead say `if authnJwtHostID == ""` => _consume variable__, which makes no sense.

There are no unit tests on the `NewClientFromEnvironment` function. These should ideally be added but should not delay this bug fix.

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
