### PR TITLE
Access token change

### DIFF
--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -116,7 +116,7 @@ func NewClientFromEnvironment(config Config) (*Client, error) {
 	}
 
 	authnToken := os.Getenv("CONJUR_AUTHN_TOKEN")
-	if authnTokenFile != "" {
+	if authnToken != "" {
 		return NewClientFromToken(config, authnToken)
 	}
 

--- a/conjurapi/client_test.go
+++ b/conjurapi/client_test.go
@@ -62,3 +62,12 @@ func Test_newClientWithAuthenticator(t *testing.T) {
 		assert.NotNil(t, client)
 	})
 }
+
+func TestNewClientFromToken(t *testing.T) {
+	t.Run("Has authenticator of type TokenAuthenticator", func(t *testing.T) {
+		client, err := NewClientFromToken(Config{Account: "account", ApplianceURL: "appliance-url"}, "token")
+
+		assert.NoError(t, err)
+		assert.IsType(t, &authn.TokenAuthenticator{}, client.authenticator)
+	})
+}


### PR DESCRIPTION
### Desired Outcome

*To fix the issue open in https://github.com/cyberark/terraform-provider-conjur/issues related to support authentication using access token issue

### Implemented Changes

*accessTokenFile variable used instead of accessToken : client.go
*test case added in client_test.go

### Connected Issue/Story

Resolves #[https://github.com/cyberark/terraform-provider-conjur/issues/69
https://github.com/cyberark/terraform-provider-conjur/issues/99
]

### Definition of Done
* 'CONJUR_AUTHN_TOKEN' : support for access token added for Terraform provider Conjur 

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes 
