### PR TITLE
Add support for authn-jwt with JWT token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-api-go#141](https://github.com/cyberark/conjur-api-go/pull/141)
 - Added support for Conjur's OIDC authenticator
   [cyberark/conjur-api-go#144](https://github.com/cyberark/conjur-api-go/pull/144)
+- Added `CONJUR_AUTHN_JWT_TOKEN` to support authenticating via authn-jwt with the contents of a JSON Web Token (JWT) [cyberark/conjur-api-go#143](https://github.com/cyberark/conjur-api-go/pull/140)
 
 ### Removed
 - Remove all usage of Conjur v4

--- a/README.md
+++ b/README.md
@@ -108,6 +108,80 @@ Connecting to Conjur is a two-step process:
 * **Configuration** Instruct the API where to find the Conjur endpoint and how to secure the connection.
 * **Authentication** Provide the API with credentials that it can use to authenticate.
 
+### Authenticating with authn-jwt via Environment Variables
+
+#### Example Code
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/cyberark/conjur-api-go/conjurapi"
+)
+
+// Environment variables to define:
+// CONJUR_APPLIANCE_URL, CONJUR_ACCOUNT, CONJUR_AUTHN_JWT_SERVICE_ID,
+// CONJUR_AUTHN_JWT_TOKEN, CONJUR_SECRET_ID
+
+func checkEnvironmentVariables() error {
+	// Check for environment variables and error if one is missing.
+	variables := []string{
+		"CONJUR_APPLIANCE_URL",
+		"CONJUR_ACCOUNT",
+		"CONJUR_AUTHN_JWT_SERVICE_ID",
+		"CONJUR_AUTHN_JWT_TOKEN",
+		"CONJUR_SECRET_ID",
+	}
+
+	for _, variable := range variables {
+		if os.Getenv(variable) == "" {
+			return fmt.Errorf("Environment variable %s is not set", variable)
+		}
+	}
+
+	return nil
+}
+
+func main() {
+
+	// Check for environment variables and error if one is missing.
+	err := checkEnvironmentVariables()
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	// Defining secret ID to retrieve, as per 12 factor
+	// this is being accomplished via env variables.
+	variableIdentifier := os.Getenv("CONJUR_SECRET_ID")
+
+	// Loading configuration via defined Env vars:
+	// CONJUR_APPLIANCE & CONJUR_ACCOUNT
+	config, err := conjurapi.LoadConfig()
+	if err != nil {
+		log.Fatalf("Cannot load configuration. %s", err)
+	}
+
+	// Create a new Conjur client using environment variables
+	conjur, err := conjurapi.NewClientFromEnvironment(config)
+	if err != nil {
+		log.Fatalf("Cannot create new client from environment variables. %s", err)
+	}
+
+	// Retrieve the secret value from Conjur
+	secretValue, err := conjur.RetrieveSecret(variableIdentifier)
+	if err != nil {
+		log.Fatalf("Cannot retrieve secret value for %s. %s", variableIdentifier, err)
+	}
+
+	// Print the secret value to stdout
+	fmt.Printf("%s", string(secretValue))
+}
+```
+
 ## Contributing
 
 We welcome contributions of all kinds to this repository. For instructions on how to get started and descriptions of our development workflows, please see our [contributing

--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -116,17 +116,21 @@ func NewClientFromEnvironment(config Config) (*Client, error) {
 
 	authnJwtServiceID := os.Getenv("CONJUR_AUTHN_JWT_SERVICE_ID")
 	if authnJwtServiceID != "" {
+		var jwtTokenString string
+		jwtToken := os.Getenv("CONJUR_AUTHN_JWT_TOKEN")
+		jwtTokenString = fmt.Sprintf("jwt=%s", jwtToken)
+		if jwtToken == "" {
+			jwtTokenPath := os.Getenv("JWT_TOKEN_PATH")
+			if jwtTokenPath == "" {
+				jwtTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+			}
 
-		jwtTokenPath := os.Getenv("JWT_TOKEN_PATH")
-		if jwtTokenPath == "" {
-			jwtTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+			jwtToken, err := ioutil.ReadFile(jwtTokenPath)
+			if err != nil {
+				return nil, err
+			}
+			jwtTokenString = fmt.Sprintf("jwt=%s", string(jwtToken))
 		}
-
-		jwtToken, err := ioutil.ReadFile(jwtTokenPath)
-		if err != nil {
-			return nil, err
-		}
-		jwtTokenString := fmt.Sprintf("jwt=%s", string(jwtToken))
 
 		var httpClient *http.Client
 		if config.IsHttps() {
@@ -144,7 +148,7 @@ func NewClientFromEnvironment(config Config) (*Client, error) {
 		}
 
 		authnJwtHostID := os.Getenv("CONJUR_AUTHN_JWT_HOST_ID")
-		authnJwtUrl := ""
+		var authnJwtUrl string
 		if authnJwtHostID != "" {
 			authnJwtUrl = makeRouterURL(config.ApplianceURL, "authn-jwt", authnJwtServiceID, config.Account, url.PathEscape(authnJwtHostID), "authenticate").String()
 		} else {


### PR DESCRIPTION
### Desired Outcome

The desired outcome of this PR is to add support for authenticating using authn-jwt through the conjur-api-go SDK where the token is provided as a raw value rather than being located in a file at a particular path that can be read.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
This PR adds a new environment variable called `CONJUR_AUTHN_JWT_TOKEN` that, when present, overrides the requirement to provide `CONJUR_TOKEN_PATH`.  If the `CONJUR_AUTHN_JWT_TOKEN` is not present, `CONJUR_TOKEN_PATH` is assumed and the typical logic established prior to this PR still applies.
- _How should the reviewer approach this PR, especially if manual tests are required?_
I have a GitLab self-hosted instance that is using this in order to authenticate with the GitLab CI generated JWT at runtime to retrieve secrets needed in the pipeline. I am happy to have a session where the reviewer can see this working in action where a test environment supporting an authn-jwt process is not available.
- _Are there relevant screenshots you can add to the PR description?_
The authn-jwt for GitLab project is located at https://github.com/infamousjoeg/authn-jwt-gitlab.  Here is the successful usage of the Go binary created and built into a Docker container in a GitLab CI pipeline utilizing the CI job's generated JWT for authentication to Conjur:
.gitlab-ci.yml
![image](https://user-images.githubusercontent.com/1924063/206530321-37fbd117-e5d2-42d4-8230-208feb9f24b7.png)
Output
![image](https://user-images.githubusercontent.com/1924063/206530498-89af86a4-e8b3-46da-828f-560f59b9dffc.png)
(Don't worry, that password has since been rotated.)

### Connected Issue/Story

Resolves # n/a

CyberArk internal issue ID: n/a

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
