### PR TITLE
Implements resource permitted-roles command in API

### DIFF
--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -318,6 +318,20 @@ func (c *Client) ResourcesRequest(filter *ResourceFilter) (*http.Request, error)
 	)
 }
 
+func (c *Client) PermittedRolesRequest(resourceID string, privilege string) (*http.Request, error) {
+	account, kind, id, err := parseID(resourceID)
+	if err != nil {
+		return nil, err
+	}
+	permittedRolesURL := makeRouterURL(c.resourcesURL(account), kind, url.QueryEscape(id)).withFormattedQuery("permitted_roles=true&privilege=%s", url.QueryEscape(privilege)).String()
+
+	return http.NewRequest(
+		"GET",
+		permittedRolesURL,
+		nil,
+	)
+}
+
 func (c *Client) LoadPolicyRequest(mode PolicyMode, policyID string, policy io.Reader) (*http.Request, error) {
 	fullPolicyID := makeFullId(c.config.Account, "policy", policyID)
 
@@ -435,7 +449,7 @@ func (c *Client) variableWithVersionURL(variableID string, version int) (string,
 		return "", err
 	}
 	return makeRouterURL(c.secretsURL(account), kind, url.PathEscape(id)).
-		withFormattedQuery("version=%d", version).String(), nil	
+		withFormattedQuery("version=%d", version).String(), nil
 }
 
 func (c *Client) batchVariableURL(variableIDs []string) string {

--- a/conjurapi/resource.go
+++ b/conjurapi/resource.go
@@ -78,9 +78,7 @@ func (c *Client) Resources(filter *ResourceFilter) (resources []map[string]inter
 	}
 
 	resources = make([]map[string]interface{}, 1)
-
 	err = json.Unmarshal(data, &resources)
-
 	return
 }
 
@@ -98,4 +96,26 @@ func (c *Client) ResourceIDs(filter *ResourceFilter) ([]string, error) {
 	}
 
 	return resourceIDs, nil
+}
+
+// PermittedRoles lists the roles which have the named permission on a resource
+func (c *Client) PermittedRoles(resourceID, privilege string) ([]string, error) {
+	req, err := c.PermittedRolesRequest(resourceID, privilege)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.SubmitRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := response.DataResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	roles := make([]string, 0)
+	err = json.Unmarshal(data, &roles)
+	return roles, nil
 }

--- a/conjurapi/resource_test.go
+++ b/conjurapi/resource_test.go
@@ -137,3 +137,18 @@ func TestClient_ResourceIDs(t *testing.T) {
 	t.Run("Lists resources and limit result to 1", listResourceIDs(conjur, &ResourceFilter{Limit: 1}, 1))
 	t.Run("Lists resources after the first", listResourceIDs(conjur, &ResourceFilter{Offset: 1}, 10))
 }
+
+func TestClient_PermittedRoles(t *testing.T) {
+	listPermittedRoles := func(conjur *Client, resourceID string, expected int) func(t *testing.T) {
+		return func(t *testing.T) {
+			roles, err := conjur.PermittedRoles(resourceID, "execute")
+			assert.NoError(t, err)
+			assert.Len(t, roles, expected)
+		}
+	}
+
+	conjur, err := conjurSetup()
+	assert.NoError(t, err)
+
+	t.Run("Lists permitted roles on a variable", listPermittedRoles(conjur, "cucumber:variable:db-password", 2))
+}


### PR DESCRIPTION
### Desired Outcome

This pull request adds an API endpoint for 'resource permitted-roles' for the Conjur CLI - Golang version.

### Implemented Changes

- Added API endpoint for 'permitted-roles'
- Added tests for API endpoint

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog (need a Changelog)

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
