### PR TITLE
Make DefaultOidcTokenPath public

### DIFF
--- a/conjurapi/authn.go
+++ b/conjurapi/authn.go
@@ -234,7 +234,7 @@ func (c *Client) rotateAPIKey(roleID string) (*http.Response, error) {
 func (c *Client) oidcTokenPath() string {
 	oidcTokenPath := c.GetConfig().OidcTokenPath
 	if oidcTokenPath == "" {
-		oidcTokenPath = defaultOidcTokenPath
+		oidcTokenPath = DefaultOidcTokenPath
 	}
 	return oidcTokenPath
 }

--- a/conjurapi/authn_test.go
+++ b/conjurapi/authn_test.go
@@ -192,7 +192,7 @@ func TestClient_OidcAuthenticate(t *testing.T) {
 			// Check that token was cached to the correct location
 			var tokenPath string
 			if tc.tokenPath == "" {
-				tokenPath = defaultOidcTokenPath
+				tokenPath = DefaultOidcTokenPath
 			} else {
 				tokenPath = tc.tokenPath
 			}

--- a/conjurapi/config.go
+++ b/conjurapi/config.go
@@ -15,7 +15,10 @@ import (
 )
 
 var supportedAuthnTypes = []string{"authn", "ldap", "oidc"}
-var defaultOidcTokenPath = os.ExpandEnv("$HOME/.conjur/oidc_token")
+
+// DefaultOidcTokenPath is the default path where the API will store the
+// access token when using authn-oidc
+var DefaultOidcTokenPath = os.ExpandEnv("$HOME/.conjur/oidc_token")
 
 type Config struct {
 	Account       string `yaml:"account,omitempty"`


### PR DESCRIPTION
Make the DefaultOidcTokenPath variable public so consuming packages (such as the CLI) can consume it.
#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
