### PR TITLE
Move credentials storage logic to API

### DIFF
--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -98,7 +98,7 @@ func LoginPairFromNetRC(config Config) (*authn.LoginPair, error) {
 		return nil, err
 	}
 
-	m := rc.FindMachine(config.ApplianceURL + "/authn")
+	m := rc.FindMachine(getMachineName(config))
 
 	if m == nil {
 		return nil, fmt.Errorf("No credentials found in NetRCPath")
@@ -196,7 +196,7 @@ func NewClientFromEnvironment(config Config) (*Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		token := client.readCachedAccessToken()
+		token := readCachedAccessToken(config)
 		if token != nil && !token.ShouldRefresh() {
 			return client, nil
 		}
@@ -237,8 +237,6 @@ func (c *Client) SubmitRequest(req *http.Request) (resp *http.Response, err erro
 }
 
 func (c *Client) submitRequestWithCustomAuth(req *http.Request) (resp *http.Response, err error) {
-
-
 	logging.ApiLog.Debugf("req: %+v\n", req)
 	resp, err = c.httpClient.Do(req)
 	if err != nil {
@@ -707,6 +705,8 @@ func newHTTPSClient(cert []byte) (*http.Client, error) {
 	if !ok {
 		return nil, fmt.Errorf("Can't append Conjur SSL cert")
 	}
+	//TODO: Test what happens if this cert is expired
+	//TODO: What if server cert is rotated
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{RootCAs: pool},
 	}

--- a/conjurapi/config.go
+++ b/conjurapi/config.go
@@ -16,19 +16,15 @@ import (
 
 var supportedAuthnTypes = []string{"authn", "ldap", "oidc"}
 
-// DefaultOidcTokenPath is the default path where the API will store the
-// access token when using authn-oidc
-var DefaultOidcTokenPath = os.ExpandEnv("$HOME/.conjur/oidc_token")
-
 type Config struct {
-	Account       string `yaml:"account,omitempty"`
-	ApplianceURL  string `yaml:"appliance_url,omitempty"`
-	NetRCPath     string `yaml:"netrc_path,omitempty"`
-	SSLCert       string `yaml:"-"`
-	SSLCertPath   string `yaml:"cert_file,omitempty"`
-	AuthnType     string `yaml:"authn_type,omitempty"`
-	ServiceID     string `yaml:"service_id,omitempty"`
-	OidcTokenPath string `yaml:"oidc_token_path,omitempty"`
+	Account             string `yaml:"account,omitempty"`
+	ApplianceURL        string `yaml:"appliance_url,omitempty"`
+	NetRCPath           string `yaml:"netrc_path,omitempty"`
+	SSLCert             string `yaml:"-"`
+	SSLCertPath         string `yaml:"cert_file,omitempty"`
+	AuthnType           string `yaml:"authn_type,omitempty"`
+	ServiceID           string `yaml:"service_id,omitempty"`
+	DontSaveCredentials bool   `yaml:"-"`
 }
 
 func (c *Config) IsHttps() bool {

--- a/conjurapi/logging/logging.go
+++ b/conjurapi/logging/logging.go
@@ -11,7 +11,8 @@ import (
 // its messages is controlled by the environment variable
 // CONJURAPI_LOG. CONJRAPI_LOG can be "stdout", "stderr", or the path
 // to a file. If it's a path, the file's contents will be overwritten
-// with new messages.
+// with new messages. If the environment variable is not set, logging
+// is disabled.
 var ApiLog = logrus.New()
 
 func init() {

--- a/conjurapi/storage.go
+++ b/conjurapi/storage.go
@@ -1,0 +1,102 @@
+package conjurapi
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/bgentry/go-netrc/netrc"
+	"github.com/cyberark/conjur-api-go/conjurapi/authn"
+)
+
+// getMachineName returns the machine name to use in the .netrc file. It contains the appliance URL
+// and the path to the authentication endpoint.
+func getMachineName(config Config) string {
+	if config.AuthnType != "" && config.AuthnType != "authn" {
+		authnType := fmt.Sprintf("authn-%s", config.AuthnType)
+		return fmt.Sprintf("%s/%s/%s", config.ApplianceURL, authnType, config.ServiceID)
+	}
+
+	return config.ApplianceURL + "/authn"
+}
+
+// storeCredentials stores credentials to the specified .netrc file
+func storeCredentials(config Config, login string, apiKey string) error {
+	machineName := getMachineName(config)
+	filePath := config.NetRCPath
+
+	_, err := os.Stat(filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			err = os.WriteFile(filePath, []byte{}, 0600)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	nrc, err := netrc.ParseFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	m := nrc.FindMachine(machineName)
+	if m == nil || m.IsDefault() {
+		_ = nrc.NewMachine(machineName, login, apiKey, "")
+	} else {
+		m.UpdateLogin(login)
+		m.UpdatePassword(apiKey)
+	}
+
+	data, err := nrc.MarshalText()
+	if err != nil {
+		return err
+	}
+
+	if data[len(data)-1] != byte('\n') {
+		data = append(data, byte('\n'))
+	}
+
+	return os.WriteFile(filePath, data, 0600)
+}
+
+// Fetches the cached conjur access token. We only do this for OIDC since we don't have access
+// to the Conjur API key and this is the only credential we can save.
+func readCachedAccessToken(config Config) *authn.AuthnToken {
+	if nrc, err := LoginPairFromNetRC(config); err == nil {
+		token, err := authn.NewToken([]byte(nrc.APIKey))
+		if err == nil {
+			token.FromJSON(token.Raw())
+			return token
+		}
+	}
+	return nil
+}
+
+// purgeCredentials purges credentials from the specified .netrc file
+func purgeCredentials(config Config) error {
+	// Remove cached credentials (username, api key) from .netrc
+	machineName := getMachineName(config)
+	filePath := config.NetRCPath
+
+	nrc, err := netrc.ParseFile(filePath)
+	if err != nil {
+		// If the .netrc file doesn't exist, we don't need to do anything
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		// Any other error should be returned
+		return err
+	}
+
+	nrc.RemoveMachine(machineName)
+
+	data, err := nrc.MarshalText()
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filePath, data, 0600)
+}

--- a/conjurapi/storage_test.go
+++ b/conjurapi/storage_test.go
@@ -1,0 +1,133 @@
+package conjurapi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoreCredentials(t *testing.T) {
+	config := setupConfig(t)
+
+	t.Run("Creates file if it does not exist", func(t *testing.T) {
+		os.Remove(config.NetRCPath)
+
+		err := storeCredentials(config, "login", "apiKey")
+		assert.NoError(t, err)
+
+		contents, err := os.ReadFile(config.NetRCPath)
+		assert.NoError(t, err)
+		assert.Contains(t, string(contents), config.ApplianceURL+"/authn")
+		assert.Contains(t, string(contents), "apiKey")
+	})
+
+	t.Run("Creates machine if it does not exist", func(t *testing.T) {
+		os.Remove(config.NetRCPath)
+		_, err := os.Create(config.NetRCPath)
+		assert.NoError(t, err)
+
+		err = storeCredentials(config, "login", "apiKey")
+		assert.NoError(t, err)
+
+		contents, err := os.ReadFile(config.NetRCPath)
+		assert.NoError(t, err)
+		assert.Contains(t, string(contents), config.ApplianceURL+"/authn")
+		assert.Contains(t, string(contents), "apiKey")
+	})
+
+	t.Run("Updates machine if it exists", func(t *testing.T) {
+		os.Remove(config.NetRCPath)
+		initialContent := `
+machine http://conjur/authn
+	login admin
+	password password`
+
+		err := os.WriteFile(config.NetRCPath, []byte(initialContent), 0600)
+		assert.NoError(t, err)
+
+		err = storeCredentials(config, "login", "apiKey")
+		assert.NoError(t, err)
+
+		contents, err := os.ReadFile(config.NetRCPath)
+		assert.NoError(t, err)
+		assert.Contains(t, string(contents), config.ApplianceURL)
+		assert.Contains(t, string(contents), "apiKey")
+	})
+
+	t.Run("Uses authn type in machine url", func(t *testing.T) {
+		os.Remove(config.NetRCPath)
+
+		oidcConfig := Config{
+			ApplianceURL: config.ApplianceURL,
+			NetRCPath:    config.NetRCPath,
+			AuthnType:    "oidc",
+			ServiceID:    "my-service",
+		}
+
+		err := storeCredentials(oidcConfig, "[oidc]", "token-contents")
+		assert.NoError(t, err)
+
+		contents, err := os.ReadFile(config.NetRCPath)
+		assert.NoError(t, err)
+		assert.Contains(t, string(contents), config.ApplianceURL+"/authn-oidc/my-service")
+		assert.Contains(t, string(contents), "token-contents")
+	})
+}
+
+func TestReadCachedAccessToken(t *testing.T) {
+	config := setupConfig(t)
+	config.AuthnType = "oidc"
+	config.ServiceID = "my-service"
+
+	t.Run("Returns token cached in netrc", func(t *testing.T) {
+		os.Remove(config.NetRCPath)
+
+		sampleTokenContents := `{"protected":"eyJhbGciOiJjb25qdXIub3JnL3Nsb3NpbG8vdjIiLCJraWQiOiI5M2VjNTEwODRmZTM3Zjc3M2I1ODhlNTYyYWVjZGMxMSJ9","payload":"eyJzdWIiOiJhZG1pbiIsImlhdCI6MTUxMDc1MzI1OX0=","signature":"raCufKOf7sKzciZInQTphu1mBbLhAdIJM72ChLB4m5wKWxFnNz_7LawQ9iYEI_we1-tdZtTXoopn_T1qoTplR9_Bo3KkpI5Hj3DB7SmBpR3CSRTnnEwkJ0_aJ8bql5Cbst4i4rSftyEmUqX-FDOqJdAztdi9BUJyLfbeKTW9OGg-QJQzPX1ucB7IpvTFCEjMoO8KUxZpbHj-KpwqAMZRooG4ULBkxp5nSfs-LN27JupU58oRgIfaWASaDmA98O2x6o88MFpxK_M0FeFGuDKewNGrRc8lCOtTQ9cULA080M5CSnruCqu1Qd52r72KIOAfyzNIiBCLTkblz2fZyEkdSKQmZ8J3AakxQE2jyHmMT-eXjfsEIzEt-IRPJIirI3Qm"}`
+		initialContent := `
+machine http://conjur/authn-oidc/my-service
+	login [oidc]
+	password ` + sampleTokenContents
+
+		err := os.WriteFile(config.NetRCPath, []byte(initialContent), 0600)
+		assert.NoError(t, err)
+
+		token := readCachedAccessToken(config)
+		assert.NotNil(t, token)
+		assert.Equal(t, sampleTokenContents, string(token.Raw()))
+	})
+
+	t.Run("Returns empty token if saved token is invalid", func(t *testing.T) {
+		os.Remove(config.NetRCPath)
+
+		initialContent := `
+machine http://conjur/authn-oidc/my-service
+	login [oidc]
+	password token-contents`
+
+		err := os.WriteFile(config.NetRCPath, []byte(initialContent), 0600)
+		assert.NoError(t, err)
+
+		token := readCachedAccessToken(config)
+		assert.Nil(t, token)
+	})
+
+	t.Run("Returns empty token if machine does not exist", func(t *testing.T) {
+		os.Remove(config.NetRCPath)
+
+		token := readCachedAccessToken(config)
+		assert.Nil(t, token)
+	})
+}
+
+func setupConfig(t *testing.T) Config {
+	tempDir := t.TempDir()
+	t.Cleanup(func() {
+		os.RemoveAll(tempDir)
+	})
+	return Config{
+		ApplianceURL: "http://conjur",
+		NetRCPath:    filepath.Join(tempDir, ".netrc"),
+	}
+}


### PR DESCRIPTION
### Desired Outcome

Until now the storage of Conjur credentials in the user's .netrc file was handled in the CLI repo. This PR moves it all to the API repo. There are (at least) three major advantages to this.
1. It can be used by summon-conjur or any other client that uses the API.
2. We can store the access token, which we use when using authn-oidc, in the .netrc just as we do with the api key for authn.
3. We can easily add other storage mechanisms (such as native system keystores) that will work with all clients of the API.

### Implemented Changes

- Moved the storage functions from the CLI repo to the API repo
- Modified the storage of the access token, used in authn-oidc, to use the same functions as the api key storage which is used in authn and authn-ldap.
- Added a config option (not saved in conjurrc) that allows clients that use the API to disable storage of credentials. This would be important for an API client that either manages it's own credential storage or keeps everything in memory only.

### Connected Issue/Story

Supports CyberArk internal issue ID: ONYX-30772

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
