### PR TITLE
Update CreateHost API

### DIFF
--- a/conjurapi/host_factory.go
+++ b/conjurapi/host_factory.go
@@ -81,7 +81,13 @@ func (c *Client) DeleteToken(token string) error {
 	return response.EmptyResponse(resp)
 }
 
-func (c *Client) CreateHost(data url.Values, token string) (HostFactoryHostResponse, error) {
+func (c *Client) CreateHost(id string, token string) (HostFactoryHostResponse, error) {
+	data := url.Values{}
+	data.Set("id", id)
+	return c.createHost(data, token)
+}
+
+func (c *Client) createHost(data url.Values, token string) (HostFactoryHostResponse, error) {
 
 	var jsonResponse HostFactoryHostResponse
 	encodedData := data.Encode()
@@ -94,13 +100,6 @@ func (c *Client) CreateHost(data url.Values, token string) (HostFactoryHostRespo
 	if err != nil {
 		return jsonResponse, err
 	}
-	respData, err := response.DataResponse(resp)
-	if err != nil {
-		return jsonResponse, err
-	}
-	err = json.Unmarshal(respData, &jsonResponse)
-	if err != nil {
-		return jsonResponse, err
-	}
-	return jsonResponse, response.EmptyResponse(resp)
+	err = response.JSONResponse(resp, &jsonResponse)
+	return jsonResponse, err
 }

--- a/conjurapi/host_factory_test.go
+++ b/conjurapi/host_factory_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/cyberark/conjur-api-go/conjurapi/authn"
 	"github.com/stretchr/testify/assert"
-	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -145,10 +144,8 @@ func TestClient_Token(t *testing.T) {
 				continue
 			}
 			t.Run("Create Host", func(t *testing.T) {
-				data := url.Values{}
-				data.Set("id", "new-host")
-				host, err := conjur.CreateHost(data, token)
-				tc.assertHost(t, len(host.ApiKey),err)
+				host, err := conjur.CreateHost("new-host", token)
+				tc.assertHost(t, len(host.ApiKey), err)
 			})
 			t.Run("Delete Token", func(t *testing.T) {
 				err := conjur.DeleteToken(token)


### PR DESCRIPTION
### Desired Outcome

The CreateHost API should just take the id string and format it correctly.

### Implemented Changes

MAde CreateHost a wrapper to createHost to take the id as an arg.

### Connected Issue/Story



CyberArk internal issue ID: [ONYX-26890]
### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
