### PR TITLE
Fixes issue with hostfactory requiring the fully qualified host factory id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Resource IDs can now be partially-qualified, adhering to the form
   [<account>:]<kind>:<identifier>.
   [cyberark/conjur-api-go#153](https://github.com/cyberark/conjur-api-go/pull/153)
+- The Hostfactory id is no longer required to be a fully qualified id.
+  [cyberark/conjur-api-go#164](https://github.com/cyberark/conjur-api-go/pull/164)
 
 ### Security
 - Upgrade gopkg.in/yaml.v3 indirect dependencies to v3.0.1 and Dockerfile to golang:1.19.5

--- a/conjurapi/host_factory.go
+++ b/conjurapi/host_factory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/cyberark/conjur-api-go/conjurapi/response"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -32,8 +33,15 @@ func (c *Client) CreateToken(durationStr string, hostFactory string, cidrs []str
 		return nil, err
 	}
 	expiration := time.Now().Add(duration).Format(time.RFC3339)
+	id := strings.SplitN(hostFactory, ":", 3)
+	if len(id) == 3 {
+		data.Set("host_factory", hostFactory)
+	} else if len(id) == 1{
+		data.Set("host_factory", c.config.Account + ":host_factory:" + hostFactory)
+	} else {
+		return nil, fmt.Errorf("malformed id '%s': ", hostFactory)
+	}
 	data.Set("expiration", expiration)
-	data.Set("host_factory", hostFactory)
 	data.Set("count", fmt.Sprint(count))
 	for _, cidr := range cidrs {
 		data.Add("cidr[]", cidr)

--- a/conjurapi/host_factory_test.go
+++ b/conjurapi/host_factory_test.go
@@ -42,6 +42,20 @@ func TestClient_Token(t *testing.T) {
 			},
 		},
 		{
+			name:        "Create a token with a partial hostfactory id",
+			duration:    "10m",
+			hostFactory: "factory",
+			count:       1,
+			cidr:        []string{"0.0.0.0/0"},
+			assert: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+			assertHost: func(t *testing.T, size int, err error) {
+				assert.NoError(t, err)
+				assert.True(t, size > 0)
+			},
+		},
+		{
 			name:        "Create a token with two cidrs",
 			duration:    "10m",
 			hostFactory: "cucumber:host_factory:factory",
@@ -100,6 +114,20 @@ func TestClient_Token(t *testing.T) {
 			name:          "Invalid duration",
 			duration:      "10",
 			hostFactory:   "cucumber:host_factory:factory",
+			count:         1,
+			cidr:          []string{"0.0.0.0/0"},
+			expectNoToken: true,
+			assert: func(t *testing.T, err error) {
+				assert.Error(t, err)
+			},
+			assertHost: func(t *testing.T, size int, err error) {
+				return
+			},
+		},
+		{
+			name:          "Invalid hostfactory id",
+			duration:      "10m",
+			hostFactory:   "cucumber:factory",
 			count:         1,
 			cidr:          []string{"0.0.0.0/0"},
 			expectNoToken: true,


### PR DESCRIPTION
### Desired Outcome

Hostfactory should not require the  fully qualified host factory id

### Implemented Changes

This inserts the account and host_factory portion of the host factory id

### Connected Issue/Story


CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
