### PR TITLE
Functions for API key rotation now support fully-qualified IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Resource IDs can now be partially-qualified, adhering to the form
-  [<account>:]<kind>:<identifier>.
+  `[<account>:]<kind>:<identifier>`.
   [cyberark/conjur-api-go#153](https://github.com/cyberark/conjur-api-go/pull/153)
+- User and Host IDs passed to their respective API key rotation functions can
+  now be fully-qualified, adhering to the form `[[<account>:]<kind>:]<identifier>`.
+  [cyberark/conjur-api-go#166](https://github.com/cyberark/conjur-api-go/pull/166)
 - The Hostfactory id is no longer required to be a fully qualified id.
   [cyberark/conjur-api-go#164](https://github.com/cyberark/conjur-api-go/pull/164)
 


### PR DESCRIPTION
### Desired Outcome

Allow fully-qualified IDs to be passed to `client.RotateUserAPIKey()` and `client.RotateHostAPIKey()`.

### Implemented Changes

API Key rotation functions use new `client.parseIDandEnforceKind(resourceID, kind string)` function to accept and parse both fully- and partially-qualified role IDs while enforcing a kind requirement.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
