### PR TITLE
Fix failing test due to different error message on CI

### DIFF
--- a/conjurapi/client_test.go
+++ b/conjurapi/client_test.go
@@ -121,7 +121,6 @@ func TestNewClientFromJwt(t *testing.T) {
 
 		// Expect it to fail without a mocked JWT server
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "no such host")
 		assert.Nil(t, client)
 	})
 


### PR DESCRIPTION
### Desired Outcome

Follow up to #169. Fixes test that succeeds locally but fails on CI due to a different error message.

### Implemented Changes

Remove the `assert.ErrorContains` line added in #169 