### PR TITLE
Update tests to account for admin user resource

### DIFF
--- a/conjurapi/resource_test.go
+++ b/conjurapi/resource_test.go
@@ -122,14 +122,14 @@ func TestClient_Resources(t *testing.T) {
 	conjur, err := conjurSetup(&Config{}, defaultTestPolicy)
 	assert.NoError(t, err)
 
-	t.Run("Lists all resources", listResources(conjur, nil, 12))
+	t.Run("Lists all resources", listResources(conjur, nil, 13))
 	t.Run("Lists resources by kind", listResources(conjur, &ResourceFilter{Kind: "variable"}, 7))
 	t.Run("Lists resources that start with db", listResources(conjur, &ResourceFilter{Search: "db"}, 2))
 	t.Run("Lists variables that start with prod/database", listResources(conjur, &ResourceFilter{Search: "prod/database", Kind: "variable"}, 2))
 	t.Run("Lists variables that start with prod", listResources(conjur, &ResourceFilter{Search: "prod", Kind: "variable"}, 4))
 	t.Run("Lists resources and limit result to 1", listResources(conjur, &ResourceFilter{Limit: 1}, 1))
 	t.Run("Lists resources after the first", listResources(conjur, &ResourceFilter{Offset: 1}, 10))
-	t.Run("Lists resources that alice can see", listResources(conjur, &ResourceFilter{Role:"cucumber:user:alice"}, 1))
+	t.Run("Lists resources that alice can see", listResources(conjur, &ResourceFilter{Role: "cucumber:user:alice"}, 1))
 }
 
 func TestClient_Resource(t *testing.T) {
@@ -158,7 +158,7 @@ func TestClient_ResourceIDs(t *testing.T) {
 	conjur, err := conjurSetup(&Config{}, defaultTestPolicy)
 	assert.NoError(t, err)
 
-	t.Run("Lists all resources", listResourceIDs(conjur, nil, 12))
+	t.Run("Lists all resources", listResourceIDs(conjur, nil, 13))
 	t.Run("Lists resources by kind", listResourceIDs(conjur, &ResourceFilter{Kind: "variable"}, 7))
 	t.Run("Lists resources that start with db", listResourceIDs(conjur, &ResourceFilter{Search: "db"}, 2))
 	t.Run("Lists variables that start with prod/database", listResourceIDs(conjur, &ResourceFilter{Search: "prod/database", Kind: "variable"}, 2))

--- a/conjurapi/role_test.go
+++ b/conjurapi/role_test.go
@@ -84,7 +84,7 @@ func TestClient_RoleMembers(t *testing.T) {
 	conjur, err := conjurSetup(&Config{}, roleTestPolicy)
 	assert.NoError(t, err)
 
-	t.Run("List role members return no members", listMembers(conjur, "cucumber:user:admin", 0))
+	t.Run("List admin role members return 1 member", listMembers(conjur, "cucumber:user:admin", 1))
 	t.Run("List role members return members", listMembers(conjur, "cucumber:layer:test-layer", 3))
 }
 
@@ -100,6 +100,6 @@ func TestClient_RoleMemberships(t *testing.T) {
 	conjur, err := conjurSetup(&Config{}, roleTestPolicy)
 	assert.NoError(t, err)
 
-	t.Run("List role memberships return memberships", listMemberships(conjur, "cucumber:user:admin", 4))
+	t.Run("List role memberships return memberships", listMemberships(conjur, "cucumber:user:admin", 5))
 	t.Run("List role memberships return no memberships", listMemberships(conjur, "cucumber:layer:test-layer", 0))
 }


### PR DESCRIPTION
### Desired Outcome

Fix conjur-api-go builds, which are currently failing in unit tests due to recent updates to Conjur. The cause is likely this PR: https://github.com/cyberark/conjur/pull/2757 which adds a resource for the admin user, which in turn is affecting some tests which use hard-coded resource/role counts as an expectation.

### Implemented Changes

Update failing unit tests to account for this recent change

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
