### PR TITLE
add ability to set http timeout

### DIFF
--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -150,13 +150,13 @@ func NewClientFromJwt(config Config, authnJwtServiceID string) (*Client, error) 
 		if err != nil {
 			return nil, err
 		}
-		httpClient, err = newHTTPSClient(cert)
+		httpClient, err = newHTTPSClient(cert, config)
 		if err != nil {
 			return nil, err
 		}
 
 	} else {
-		httpClient = &http.Client{Timeout: time.Second * 10}
+		httpClient = &http.Client{Timeout: time.Second * time.Duration(config.HttpTimeout)}
 	}
 
 	authnJwtHostID := os.Getenv("CONJUR_AUTHN_JWT_HOST_ID")
@@ -827,12 +827,12 @@ func createHttpClient(config Config) (*http.Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		httpClient, err = newHTTPSClient(cert)
+		httpClient, err = newHTTPSClient(cert, config)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		httpClient = &http.Client{Timeout: time.Second * 10}
+		httpClient = &http.Client{Timeout: time.Second * time.Duration(config.HttpTimeout)}
 	}
 	return httpClient, nil
 }
@@ -847,7 +847,7 @@ func newClientWithAuthenticator(config Config, authenticator Authenticator) (*Cl
 	return client, nil
 }
 
-func newHTTPSClient(cert []byte) (*http.Client, error) {
+func newHTTPSClient(cert []byte, config Config) (*http.Client, error) {
 	pool := x509.NewCertPool()
 	ok := pool.AppendCertsFromPEM(cert)
 	if !ok {
@@ -858,5 +858,5 @@ func newHTTPSClient(cert []byte) (*http.Client, error) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{RootCAs: pool},
 	}
-	return &http.Client{Transport: tr, Timeout: time.Second * 10}, nil
+	return &http.Client{Transport: tr, Timeout: time.Second * time.Duration(config.HttpTimeout)}, nil
 }

--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -156,7 +156,7 @@ func NewClientFromJwt(config Config, authnJwtServiceID string) (*Client, error) 
 		}
 
 	} else {
-		httpClient = &http.Client{Timeout: time.Second * time.Duration(config.HttpTimeout)}
+		httpClient = &http.Client{Timeout: time.Second * time.Duration(config.GetHttpTimeout())}
 	}
 
 	authnJwtHostID := os.Getenv("CONJUR_AUTHN_JWT_HOST_ID")
@@ -832,7 +832,7 @@ func createHttpClient(config Config) (*http.Client, error) {
 			return nil, err
 		}
 	} else {
-		httpClient = &http.Client{Timeout: time.Second * time.Duration(config.HttpTimeout)}
+		httpClient = &http.Client{Timeout: time.Second * time.Duration(config.GetHttpTimeout())}
 	}
 	return httpClient, nil
 }
@@ -858,5 +858,5 @@ func newHTTPSClient(cert []byte, config Config) (*http.Client, error) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{RootCAs: pool},
 	}
-	return &http.Client{Transport: tr, Timeout: time.Second * time.Duration(config.HttpTimeout)}, nil
+	return &http.Client{Transport: tr, Timeout: time.Second * time.Duration(config.GetHttpTimeout())}, nil
 }

--- a/conjurapi/client_test.go
+++ b/conjurapi/client_test.go
@@ -407,13 +407,15 @@ func TestClient_createHttpClient(t *testing.T) {
 
 func TestClient_newHTTPSClient(t *testing.T) {
 	t.Run("New HTTPS client error with invalid cert", func(t *testing.T) {
-		client, err := newHTTPSClient([]byte("invalid cert"))
+		config := Config{}
+		client, err := newHTTPSClient([]byte("invalid cert"), config)
 
 		assert.EqualError(t, err, "Can't append Conjur SSL cert")
 		assert.Nil(t, client)
 	})
 	t.Run("New HTTPS client with valid cert", func(t *testing.T) {
-		client, err := newHTTPSClient([]byte(sample_cert))
+		config := Config{}
+		client, err := newHTTPSClient([]byte(sample_cert), config)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, client)

--- a/conjurapi/client_test.go
+++ b/conjurapi/client_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cyberark/conjur-api-go/conjurapi/authn"
 	"github.com/stretchr/testify/assert"
@@ -419,6 +420,33 @@ func TestClient_newHTTPSClient(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
+	})
+}
+
+func TestClient_HttpClientTimeoutValue(t *testing.T) {
+	t.Run("Create HTTP client with default timeout value", func(t *testing.T) {
+		config := Config{Account: "account", ApplianceURL: "http://appliance-url"}
+		client, err := createHttpClient(config)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.Equal(t, time.Second * time.Duration(HttpTimeoutDefaultValue), client.Timeout)
+	})
+	t.Run("Create HTTP client with no timeout", func(t *testing.T) {
+		config := Config{Account: "account", ApplianceURL: "http://appliance-url", HttpTimeout: -1}
+		client, err := createHttpClient(config)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.Equal(t, time.Second * time.Duration(0), client.Timeout)
+	})
+	t.Run("Create HTTP client with specific timeout", func(t *testing.T) {
+		config := Config{Account: "account", ApplianceURL: "http://appliance-url", HttpTimeout: 5}
+		client, err := createHttpClient(config)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.Equal(t, time.Second * time.Duration(5), client.Timeout)
 	})
 }
 

--- a/conjurapi/config_test.go
+++ b/conjurapi/config_test.go
@@ -149,7 +149,6 @@ func TestConfig_LoadFromEnv(t *testing.T) {
 		os.Setenv("CONJUR_AUTHN_TYPE", "ldap")
 		os.Setenv("CONJUR_SERVICE_ID", "service-id")
 		os.Setenv("CONJUR_CREDENTIAL_STORAGE", "keyring")
-		os.Setenv("CONJUR_HTTP_TIMEOUT", "10")
 
 		t.Run("Returns Config loaded with values from env", func(t *testing.T) {
 			config := &Config{}
@@ -161,7 +160,6 @@ func TestConfig_LoadFromEnv(t *testing.T) {
 				AuthnType:         "ldap",
 				ServiceID:         "service-id",
 				CredentialStorage: "keyring",
-				HttpTimeout:       10,
 			})
 		})
 	})
@@ -211,7 +209,6 @@ cert_file: "/path/to/cert/file/pem%v"
 netrc_path: "/path/to/netrc/file%v"
 authn_type: ldap
 service_id: my-ldap-service
-http_timeout: 10
 %s
 `, index, index, index, index, versiontest.in)
 
@@ -230,7 +227,6 @@ http_timeout: 10
 					SSLCertPath:  fmt.Sprintf("/path/to/cert/file/pem%v", index),
 					AuthnType:    "ldap",
 					ServiceID:    "my-ldap-service",
-					HttpTimeout:  10,
 				})
 			})
 		})
@@ -301,7 +297,6 @@ appliance_url: test-appliance-url
 			NetRCPath:         "test-netrc-path",
 			SSLCert:           "test-cert",
 			CredentialStorage: "keyring",
-			HttpTimeout:       10,
 		},
 		expected: `account: test-account
 appliance_url: test-appliance-url
@@ -310,7 +305,6 @@ cert_file: test-cert-path
 authn_type: oidc
 service_id: test-service-id
 credential_storage: keyring
-http_timeout: 10
 `,
 	},
 }
@@ -405,6 +399,40 @@ func TestConfig_BaseURL(t *testing.T) {
 
 			actual := config.BaseURL()
 			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}
+
+func TestConfig_GetHttpTimeout(t *testing.T) {
+	testCases := []struct {
+		name                string
+		configHttpTimeout   int
+		expectedHttpTimeout int
+	}{
+		{
+			name:                "smaller than zero",
+			configHttpTimeout:   -1,
+			expectedHttpTimeout: 0,
+		},
+		{
+			name:                "equal to zero",
+			configHttpTimeout:   0,
+			expectedHttpTimeout: HttpTimeoutDefaultValue,
+		},
+		{
+			name:                "greater then zero",
+			configHttpTimeout:   5,
+			expectedHttpTimeout: 5,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			config := Config{
+				HttpTimeout: testCase.configHttpTimeout,
+			}
+
+			assert.Equal(t, testCase.expectedHttpTimeout, config.GetHttpTimeout())
 		})
 	}
 }

--- a/conjurapi/config_test.go
+++ b/conjurapi/config_test.go
@@ -149,6 +149,7 @@ func TestConfig_LoadFromEnv(t *testing.T) {
 		os.Setenv("CONJUR_AUTHN_TYPE", "ldap")
 		os.Setenv("CONJUR_SERVICE_ID", "service-id")
 		os.Setenv("CONJUR_CREDENTIAL_STORAGE", "keyring")
+		os.Setenv("CONJUR_HTTP_TIMEOUT", "10")
 
 		t.Run("Returns Config loaded with values from env", func(t *testing.T) {
 			config := &Config{}
@@ -160,6 +161,7 @@ func TestConfig_LoadFromEnv(t *testing.T) {
 				AuthnType:         "ldap",
 				ServiceID:         "service-id",
 				CredentialStorage: "keyring",
+				HttpTimeout:       10,
 			})
 		})
 	})
@@ -209,6 +211,7 @@ cert_file: "/path/to/cert/file/pem%v"
 netrc_path: "/path/to/netrc/file%v"
 authn_type: ldap
 service_id: my-ldap-service
+http_timeout: 10
 %s
 `, index, index, index, index, versiontest.in)
 
@@ -227,6 +230,7 @@ service_id: my-ldap-service
 					SSLCertPath:  fmt.Sprintf("/path/to/cert/file/pem%v", index),
 					AuthnType:    "ldap",
 					ServiceID:    "my-ldap-service",
+					HttpTimeout:  10,
 				})
 			})
 		})
@@ -297,6 +301,7 @@ appliance_url: test-appliance-url
 			NetRCPath:         "test-netrc-path",
 			SSLCert:           "test-cert",
 			CredentialStorage: "keyring",
+			HttpTimeout:       10,
 		},
 		expected: `account: test-account
 appliance_url: test-appliance-url
@@ -305,6 +310,7 @@ cert_file: test-cert-path
 authn_type: oidc
 service_id: test-service-id
 credential_storage: keyring
+http_timeout: 10
 `,
 	},
 }


### PR DESCRIPTION
### Desired Outcome

The aim is to be able to set the http client timeout, which is currently set to 10 seconds in the code.

### Implemented Changes

The modification consists in adding the "HttpTimeout" integer to the "Config" structure and using it when instantiating the "http.Client" object.

#### Test coverage

- This PR includes new unit and integration tests to go with the code
  changes
