### PR TITLE
Adding Proxy support

### DIFF
--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -857,6 +857,7 @@ func newHTTPSClient(cert []byte, config Config) (*http.Client, error) {
 	//TODO: What if server cert is rotated
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{RootCAs: pool},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 	return &http.Client{Transport: tr, Timeout: time.Second * time.Duration(config.GetHttpTimeout())}, nil
 }


### PR DESCRIPTION
### Desired Outcome

Conjur API uses the net/http module which supports proxy.
When creating a new HTTPS client we ignore proxy configuration at http.Transport 

### Implemented Changes

http.ProxyFromEnvironment was added to http.Transport - we now support http_proxy, https_proxy, no_proxy from env params.

