### PR TITLE
Change handling of proxy config

### DIFF
--- a/conjurapi/client.go
+++ b/conjurapi/client.go
@@ -410,6 +410,8 @@ func newHTTPTransport(cfg Config) *http.Transport {
 	}).DialContext
 	if cfg.ProxyURL() != nil {
 		tr.Proxy = http.ProxyURL(cfg.ProxyURL())
+	} else {
+		tr.Proxy = http.ProxyFromEnvironment
 	}
 	tr.DisableKeepAlives = cfg.DisableKeepAlives
 	return tr

--- a/conjurapi/config.go
+++ b/conjurapi/config.go
@@ -244,7 +244,6 @@ func (c *Config) mergeEnv() {
 		HTTPTimeout:       httpTimoutFromEnv(),
 		DisableKeepAlives: disableKeepAlivesFromEnv(),
 		Environment:       EnvironmentType(os.Getenv("CONJUR_ENVIRONMENT")),
-		Proxy:             os.Getenv("HTTPS_PROXY"),
 		AzureClientID:     os.Getenv("CONJUR_AUTHN_AZURE_CLIENT_ID"),
 	}
 


### PR DESCRIPTION
Rely on net/http lib's ProxyFromEnvironment if no explicit proxy is configured. This also considers NO_PROXY environment variables which otherwise have been ignored.

### Desired Outcome

This fixes an issue where `NO_PROXY` environment variable weren't being considered when executing the conjur CLI with `HTTPS_PROXY` env variable set.

The behavior of the CLI hasn't changed. Explicitly configured proxy still takes priority and `NO_PROXY` env var still ignored in this case.

### Implemented Changes

- Removed `Proxy` from `mergeEnv` function in `config.go`.
- Setting `tr.Proxy` with `http.ProxyFromEnvironment` in `newHTTPTransport` function inside `client.go` if proxy hasn't been configured explicitly.

### Connected Issue/Story

n/a

### Definition of Done

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
